### PR TITLE
feat: JSONRPC & REST request validation patterns

### DIFF
--- a/src/bin/ucp-schema.rs
+++ b/src/bin/ucp-schema.rs
@@ -10,7 +10,7 @@ use ucp_schema::{
     bundle_refs, bundle_refs_with_url_mapping, compose_from_payload, compose_schema,
     detect_direction, extract_capabilities_from_profile, extract_jsonrpc_payload, is_url, lint,
     load_schema, load_schema_auto, resolve, validate, ComposeError, DetectedDirection, Direction,
-    FileStatus, ResolveOptions, ResolveError, SchemaBaseConfig, ValidateError,
+    FileStatus, ResolveError, ResolveOptions, SchemaBaseConfig, ValidateError,
 };
 
 /// Errors with associated CLI exit codes.

--- a/src/bin/ucp-schema.rs
+++ b/src/bin/ucp-schema.rs
@@ -7,10 +7,68 @@ use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
 use ucp_schema::{
-    bundle_refs, compose_from_payload, detect_direction, lint, load_schema, load_schema_auto,
-    resolve, validate, DetectedDirection, Direction, FileStatus, ResolveOptions, SchemaBaseConfig,
-    ValidateError,
+    bundle_refs, bundle_refs_with_url_mapping, compose_from_payload, compose_schema,
+    detect_direction, extract_capabilities_from_profile, extract_jsonrpc_payload, is_url, lint,
+    load_schema, load_schema_auto, resolve, validate, ComposeError, DetectedDirection, Direction,
+    FileStatus, ResolveOptions, ResolveError, SchemaBaseConfig, ValidateError,
 };
+
+/// Errors with associated CLI exit codes.
+trait CliExitCode {
+    fn exit_code(&self) -> u8;
+}
+
+impl CliExitCode for ResolveError {
+    fn exit_code(&self) -> u8 {
+        ResolveError::exit_code(self) as u8
+    }
+}
+
+impl CliExitCode for ComposeError {
+    fn exit_code(&self) -> u8 {
+        ComposeError::exit_code(self) as u8
+    }
+}
+
+/// Map an error to a CLI exit code, reporting it in the configured format.
+fn cli_err<E: std::fmt::Display + CliExitCode>(json_output: bool) -> impl FnOnce(E) -> u8 {
+    move |e| {
+        report_error(json_output, &e.to_string());
+        e.exit_code()
+    }
+}
+
+/// Like cli_err but with a message prefix for additional context.
+fn cli_err_ctx<'a, E: std::fmt::Display + CliExitCode>(
+    json_output: bool,
+    context: &'a str,
+) -> impl FnOnce(E) -> u8 + 'a {
+    move |e| {
+        report_error(json_output, &format!("{}: {}", context, e));
+        e.exit_code()
+    }
+}
+
+/// Determine direction from CLI flags and optional inference.
+///
+/// Priority: explicit --request/--response flags override inference.
+/// When neither flag is set, uses inferred direction or defaults to Request.
+fn determine_direction(
+    request_flag: bool,
+    response_flag: bool,
+    inferred: Option<Direction>,
+) -> Direction {
+    if request_flag {
+        Direction::Request
+    } else if response_flag {
+        Direction::Response
+    } else {
+        inferred.unwrap_or(Direction::Request)
+    }
+}
+
+#[cfg(feature = "remote")]
+use ucp_schema::bundle_refs_remote;
 
 #[derive(Parser)]
 #[command(name = "ucp-schema")]
@@ -78,6 +136,10 @@ enum Commands {
         #[arg(long, requires = "schema_local_base")]
         schema_remote_base: Option<String>,
 
+        /// Agent profile URL (REST pattern: profile via header, payload is raw object)
+        #[arg(long, conflicts_with = "schema")]
+        profile: Option<String>,
+
         /// Validate as request (auto-inferred if omitted)
         #[arg(long, conflicts_with = "response")]
         request: bool,
@@ -138,6 +200,7 @@ fn main() -> ExitCode {
             schema,
             schema_local_base,
             schema_remote_base,
+            profile,
             request,
             response,
             op,
@@ -148,6 +211,7 @@ fn main() -> ExitCode {
             schema,
             schema_local_base,
             schema_remote_base,
+            profile,
             request,
             response,
             op,
@@ -178,12 +242,10 @@ fn run_resolve(
     bundle: bool,
     strict: bool,
 ) -> Result<(), u8> {
+    // run_resolve has no --json flag, so errors always go to stderr (json_output=false)
     let direction = Direction::from_request_flag(request);
 
-    let mut schema = load_schema_auto(schema_source).map_err(|e| {
-        eprintln!("Error: {}", e);
-        e.exit_code() as u8
-    })?;
+    let mut schema = load_schema_auto(schema_source).map_err(cli_err(false))?;
 
     // Bundle: dereference all $refs before resolving annotations
     if bundle {
@@ -192,17 +254,11 @@ fn run_resolve(
         let base_dir = std::path::Path::new(schema_source)
             .parent()
             .unwrap_or(std::path::Path::new("."));
-        bundle_refs(&mut schema, base_dir).map_err(|e| {
-            eprintln!("Error bundling refs: {}", e);
-            e.exit_code() as u8
-        })?;
+        bundle_refs(&mut schema, base_dir).map_err(cli_err_ctx(false, "bundling refs"))?;
     }
 
     let options = ResolveOptions::new(direction, op).strict(strict);
-    let resolved = resolve(&schema, &options).map_err(|e| {
-        eprintln!("Error: {}", e);
-        e.exit_code() as u8
-    })?;
+    let resolved = resolve(&schema, &options).map_err(cli_err(false))?;
 
     let json_output = if pretty {
         serde_json::to_string_pretty(&resolved)
@@ -234,6 +290,7 @@ struct ValidateArgs {
     schema: Option<String>,
     schema_local_base: Option<PathBuf>,
     schema_remote_base: Option<String>,
+    profile: Option<String>,
     request: bool,
     response: bool,
     op: String,
@@ -247,55 +304,117 @@ fn run_validate(args: ValidateArgs) -> Result<(), u8> {
         schema: schema_source,
         schema_local_base,
         schema_remote_base,
+        profile: profile_url,
         request,
         response,
         op,
         json_output,
         strict,
     } = args;
-    // Load payload first - needed for both explicit and self-describing modes
-    let payload = load_schema(&payload_path).map_err(|e| {
-        report_error(json_output, &format!("loading payload: {}", e));
-        e.exit_code() as u8
-    })?;
 
-    // Determine direction: explicit flag > auto-inference from payload
-    let direction = if request {
-        Direction::Request
-    } else if response {
-        Direction::Response
-    } else {
-        // Auto-infer from payload structure
-        match detect_direction(&payload) {
-            Some(DetectedDirection::Response) => Direction::Response,
-            Some(DetectedDirection::Request) => Direction::Request,
-            None => {
-                // No UCP metadata found - require explicit flag
-                report_error(json_output, "cannot infer direction: payload has no ucp.capabilities or ucp.meta.profile. Use --request or --response.");
-                return Err(2);
-            }
-        }
+    let config = SchemaBaseConfig {
+        local_base: schema_local_base.as_deref(),
+        remote_base: schema_remote_base.as_deref(),
     };
 
-    // Get schema: explicit --schema or compose from payload metadata
-    let schema = match &schema_source {
-        Some(source) => {
-            // Explicit schema - load directly
-            load_schema_auto(source).map_err(|e| {
-                report_error(json_output, &format!("loading schema: {}", e));
-                e.exit_code() as u8
-            })?
+    // Load payload file
+    let payload_file =
+        load_schema(&payload_path).map_err(cli_err_ctx(json_output, "loading payload"))?;
+
+    // Determine validation mode and extract actual payload to validate:
+    // 1. --profile: REST pattern, payload is raw object
+    // 2. --schema: explicit schema, payload is raw object
+    // 3. JSONRPC: meta.profile in payload, extract nested payload
+    // 4. Response: ucp.capabilities in payload, payload is self-describing
+    let (schema, payload, direction) = if let Some(ref profile) = profile_url {
+        // REST pattern: --profile flag provides profile URL, payload is raw
+        let direction = determine_direction(request, response, None);
+
+        let capabilities =
+            extract_capabilities_from_profile(profile, &config).map_err(cli_err(json_output))?;
+
+        let schema = compose_schema(&capabilities, &config).map_err(cli_err(json_output))?;
+
+        (schema, payload_file, direction)
+    } else if let Some(ref source) = schema_source {
+        // Explicit schema: try to infer direction from payload
+        let inferred = detect_direction(&payload_file).map(Direction::from);
+        let direction = determine_direction(request, response, inferred);
+
+        let mut schema =
+            load_schema_auto(source).map_err(cli_err_ctx(json_output, "loading schema"))?;
+
+        // Bundle refs based on source type and available mappings
+        #[cfg(feature = "remote")]
+        {
+            if is_url(source) {
+                bundle_refs_remote(&mut schema, source)
+                    .map_err(cli_err_ctx(json_output, "bundling refs"))?;
+            } else {
+                bundle_local_refs(
+                    &mut schema,
+                    source,
+                    &schema_local_base,
+                    &schema_remote_base,
+                    json_output,
+                )?;
+            }
         }
-        None => {
-            // Self-describing mode - compose from payload's UCP metadata
-            let config = SchemaBaseConfig {
-                local_base: schema_local_base.as_deref(),
-                remote_base: schema_remote_base.as_deref(),
-            };
-            compose_from_payload(&payload, &config).map_err(|e| {
-                report_error(json_output, &e.to_string());
-                e.exit_code() as u8
-            })?
+        #[cfg(not(feature = "remote"))]
+        {
+            bundle_local_refs(
+                &mut schema,
+                source,
+                &schema_local_base,
+                &schema_remote_base,
+                json_output,
+            )?;
+        }
+
+        (schema, payload_file, direction)
+    } else {
+        // Self-describing mode - detect from payload structure
+        match detect_direction(&payload_file) {
+            Some(DetectedDirection::Response) => {
+                // Response: ucp.capabilities, compose and validate full payload
+                let direction = determine_direction(request, response, Some(Direction::Response));
+                let schema =
+                    compose_from_payload(&payload_file, &config).map_err(cli_err(json_output))?;
+                (schema, payload_file, direction)
+            }
+            Some(DetectedDirection::Request) => {
+                // JSONRPC request: meta.profile, extract nested payload
+                let direction = determine_direction(request, response, Some(Direction::Request));
+
+                // Get profile URL from meta.profile
+                let profile = payload_file
+                    .get("meta")
+                    .and_then(|m| m.get("profile"))
+                    .and_then(|p| p.as_str())
+                    .ok_or_else(|| {
+                        report_error(json_output, "JSONRPC request missing meta.profile");
+                        2u8
+                    })?;
+
+                let capabilities = extract_capabilities_from_profile(profile, &config)
+                    .map_err(cli_err(json_output))?;
+
+                // Extract actual payload from envelope (e.g., "checkout" key)
+                let (nested_payload, _key) = extract_jsonrpc_payload(&payload_file, &capabilities)
+                    .map_err(cli_err(json_output))?;
+
+                let schema =
+                    compose_schema(&capabilities, &config).map_err(cli_err(json_output))?;
+
+                (schema, nested_payload.clone(), direction)
+            }
+            None => {
+                report_error(
+                    json_output,
+                    "cannot infer direction: payload has no ucp.capabilities (response) or meta.profile (request). Use --schema, --profile, --request, or --response.",
+                );
+                return Err(2);
+            }
         }
     };
 
@@ -332,10 +451,37 @@ fn run_validate(args: ValidateArgs) -> Result<(), u8> {
     }
 }
 
+/// Bundle refs for a local schema file.
+fn bundle_local_refs(
+    schema: &mut serde_json::Value,
+    source: &str,
+    schema_local_base: &Option<PathBuf>,
+    schema_remote_base: &Option<String>,
+    json_output: bool,
+) -> Result<(), u8> {
+    let schema_dir = Path::new(source).parent().unwrap_or(Path::new("."));
+
+    if let (Some(local_base), Some(remote_base)) = (schema_local_base, schema_remote_base) {
+        bundle_refs_with_url_mapping(schema, schema_dir, local_base, remote_base)
+            .map_err(cli_err_ctx(json_output, "bundling refs"))?;
+    } else {
+        bundle_refs(schema, schema_dir).map_err(cli_err_ctx(json_output, "bundling refs"))?;
+    }
+
+    Ok(())
+}
+
 /// Output an error message in plain text or JSON format.
+///
+/// Uses same shape as validation errors for consistent API:
+/// `{"valid": false, "errors": [{"path": "", "message": "..."}]}`
 fn report_error(json_output: bool, msg: &str) {
     if json_output {
-        println!(r#"{{"valid":false,"error":"{}"}}"#, msg);
+        let output = serde_json::json!({
+            "valid": false,
+            "errors": [{"path": "", "message": msg}]
+        });
+        println!("{}", output);
     } else {
         eprintln!("Error: {}", msg);
     }

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -44,8 +44,8 @@ use std::path::Path;
 use serde_json::{json, Value};
 
 use crate::error::ComposeError;
-use crate::types::Direction;
 use crate::loader::{bundle_refs, bundle_refs_with_url_mapping, is_url, load_schema};
+use crate::types::Direction;
 
 #[cfg(feature = "remote")]
 use crate::loader::{bundle_refs_remote, load_schema_url};
@@ -113,11 +113,7 @@ pub fn detect_direction(payload: &Value) -> Option<DetectedDirection> {
     }
 
     // JSONRPC request pattern: meta.profile at root (NOT ucp.meta.profile)
-    if payload
-        .get("meta")
-        .and_then(|m| m.get("profile"))
-        .is_some()
-    {
+    if payload.get("meta").and_then(|m| m.get("profile")).is_some() {
         return Some(DetectedDirection::Request);
     }
 
@@ -198,12 +194,14 @@ pub fn extract_jsonrpc_payload<'a>(
     let short_name = capability_short_name(&root.name);
 
     // Extract payload from envelope using short name as key
-    let payload = envelope.get(&short_name).ok_or_else(|| ComposeError::InvalidEnvelope {
-        message: format!(
-            "JSONRPC envelope missing '{}' key (derived from capability '{}')",
-            short_name, root.name
-        ),
-    })?;
+    let payload = envelope
+        .get(&short_name)
+        .ok_or_else(|| ComposeError::InvalidEnvelope {
+            message: format!(
+                "JSONRPC envelope missing '{}' key (derived from capability '{}')",
+                short_name, root.name
+            ),
+        })?;
 
     Ok((payload, short_name))
 }

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -17,18 +17,26 @@
 //! }
 //! ```
 //!
-//! # Request Pattern
+//! # Request Pattern (JSONRPC)
 //!
-//! Requests reference a profile URL:
+//! JSONRPC requests have `meta.profile` at root, with payload nested under
+//! the capability short name (last segment of the dotted capability name):
 //! ```json
 //! {
-//!   "ucp": {
-//!     "meta": {
-//!       "profile": "https://agent.example.com/.well-known/ucp"
-//!     }
+//!   "meta": {
+//!     "profile": "https://agent.example.com/.well-known/ucp"
+//!   },
+//!   "checkout": {
+//!     "line_items": [...]
 //!   }
 //! }
 //! ```
+//!
+//! # Request Pattern (REST)
+//!
+//! REST requests pass the profile URL via HTTP header (`UCP-Agent`), with
+//! the payload being the raw checkout object. Use `--profile` CLI flag to
+//! simulate this pattern.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -36,10 +44,11 @@ use std::path::Path;
 use serde_json::{json, Value};
 
 use crate::error::ComposeError;
+use crate::types::Direction;
 use crate::loader::{bundle_refs, bundle_refs_with_url_mapping, is_url, load_schema};
 
 #[cfg(feature = "remote")]
-use crate::loader::load_schema_url;
+use crate::loader::{bundle_refs_remote, load_schema_url};
 
 /// Configuration for mapping schema URLs to local paths.
 ///
@@ -77,23 +86,38 @@ pub struct Capability {
 pub enum DetectedDirection {
     /// Payload has `ucp.capabilities` inline (response pattern).
     Response,
-    /// Payload has `ucp.meta.profile` URL (request pattern).
+    /// Payload has `meta.profile` at root (JSONRPC request pattern).
     Request,
+}
+
+impl From<DetectedDirection> for Direction {
+    fn from(d: DetectedDirection) -> Self {
+        match d {
+            DetectedDirection::Response => Direction::Response,
+            DetectedDirection::Request => Direction::Request,
+        }
+    }
 }
 
 /// Detect direction from payload structure.
 ///
 /// Returns `Some(Response)` if `ucp.capabilities` exists,
-/// `Some(Request)` if `ucp.meta.profile` exists,
+/// `Some(Request)` if `meta.profile` exists at root (JSONRPC pattern),
 /// `None` if neither is present.
 pub fn detect_direction(payload: &Value) -> Option<DetectedDirection> {
-    let ucp = payload.get("ucp")?;
-
-    if ucp.get("capabilities").is_some() {
-        return Some(DetectedDirection::Response);
+    // Response pattern: ucp.capabilities
+    if let Some(ucp) = payload.get("ucp") {
+        if ucp.get("capabilities").is_some() {
+            return Some(DetectedDirection::Response);
+        }
     }
 
-    if ucp.get("meta").and_then(|m| m.get("profile")).is_some() {
+    // JSONRPC request pattern: meta.profile at root (NOT ucp.meta.profile)
+    if payload
+        .get("meta")
+        .and_then(|m| m.get("profile"))
+        .is_some()
+    {
         return Some(DetectedDirection::Request);
     }
 
@@ -103,7 +127,7 @@ pub fn detect_direction(payload: &Value) -> Option<DetectedDirection> {
 /// Extract capabilities from a self-describing payload.
 ///
 /// - Response: extracts from `ucp.capabilities` directly
-/// - Request: fetches `ucp.meta.profile` URL, extracts from profile
+/// - JSONRPC Request: fetches `meta.profile` URL, extracts from profile
 ///
 /// # Arguments
 /// * `payload` - The UCP payload to extract capabilities from
@@ -112,31 +136,84 @@ pub fn extract_capabilities(
     payload: &Value,
     schema_base: &SchemaBaseConfig,
 ) -> Result<Vec<Capability>, ComposeError> {
-    let ucp = payload.get("ucp").ok_or(ComposeError::NotSelfDescribing)?;
-
     // Try response pattern first: ucp.capabilities
-    if let Some(caps) = ucp.get("capabilities") {
-        return parse_capabilities_object(caps);
+    if let Some(ucp) = payload.get("ucp") {
+        if let Some(caps) = ucp.get("capabilities") {
+            return parse_capabilities_object(caps);
+        }
     }
 
-    // Try request pattern: ucp.meta.profile
-    if let Some(profile_url) = ucp
+    // Try JSONRPC request pattern: meta.profile at root
+    if let Some(profile_url) = payload
         .get("meta")
         .and_then(|m| m.get("profile"))
         .and_then(|p| p.as_str())
     {
-        let profile = fetch_profile(profile_url, schema_base)?;
-        let caps = profile
-            .get("ucp")
-            .and_then(|u| u.get("capabilities"))
-            .ok_or_else(|| ComposeError::ProfileFetch {
-                url: profile_url.to_string(),
-                message: "profile missing ucp.capabilities".to_string(),
-            })?;
-        return parse_capabilities_object(caps);
+        return extract_capabilities_from_profile(profile_url, schema_base);
     }
 
     Err(ComposeError::NotSelfDescribing)
+}
+
+/// Extract capabilities from a profile URL.
+///
+/// Used for both JSONRPC requests (meta.profile) and REST requests (--profile flag).
+pub fn extract_capabilities_from_profile(
+    profile_url: &str,
+    schema_base: &SchemaBaseConfig,
+) -> Result<Vec<Capability>, ComposeError> {
+    let profile = fetch_profile(profile_url, schema_base)?;
+    let caps = profile
+        .get("ucp")
+        .and_then(|u| u.get("capabilities"))
+        .ok_or_else(|| ComposeError::ProfileFetch {
+            url: profile_url.to_string(),
+            message: "profile missing ucp.capabilities".to_string(),
+        })?;
+    parse_capabilities_object(caps)
+}
+
+/// Extract the actual payload from a JSONRPC request envelope.
+///
+/// JSONRPC requests have the structure: `{meta: {...}, <capability_key>: <payload>}`
+/// The capability key is the short name (last segment) of the root capability.
+///
+/// # Arguments
+/// * `envelope` - The full JSONRPC request envelope
+/// * `capabilities` - Capabilities extracted from the profile
+///
+/// # Returns
+/// The payload value and the capability key name used
+pub fn extract_jsonrpc_payload<'a>(
+    envelope: &'a Value,
+    capabilities: &[Capability],
+) -> Result<(&'a Value, String), ComposeError> {
+    // Find root capability (no extends)
+    let root = capabilities
+        .iter()
+        .find(|c| c.extends.is_none())
+        .ok_or(ComposeError::NoRootCapability)?;
+
+    // Derive short name from capability name (last segment of dotted name)
+    let short_name = capability_short_name(&root.name);
+
+    // Extract payload from envelope using short name as key
+    let payload = envelope.get(&short_name).ok_or_else(|| ComposeError::InvalidEnvelope {
+        message: format!(
+            "JSONRPC envelope missing '{}' key (derived from capability '{}')",
+            short_name, root.name
+        ),
+    })?;
+
+    Ok((payload, short_name))
+}
+
+/// Derive short name from a capability name.
+///
+/// Takes the last segment of a dotted capability name.
+/// E.g., "dev.ucp.shopping.checkout" -> "checkout"
+pub fn capability_short_name(name: &str) -> String {
+    name.rsplit('.').next().unwrap_or(name).to_string()
 }
 
 /// Parse a capabilities object into a list of Capability structs.
@@ -489,13 +566,21 @@ fn resolve_schema_url(url: &str, schema_base: &SchemaBaseConfig) -> Result<Value
 
         Ok(schema)
     } else if is_url(url) {
-        // HTTP fetch - bundling not supported for remote-only schemas
+        // HTTP fetch with remote bundling
         #[cfg(feature = "remote")]
         {
-            load_schema_url(url).map_err(|e| ComposeError::SchemaFetch {
+            let mut schema = load_schema_url(url).map_err(|e| ComposeError::SchemaFetch {
                 url: url.to_string(),
                 message: e.to_string(),
-            })
+            })?;
+
+            // Bundle refs using the URL as base for resolving relative refs
+            bundle_refs_remote(&mut schema, url).map_err(|e| ComposeError::SchemaFetch {
+                url: url.to_string(),
+                message: format!("bundling refs: {}", e),
+            })?;
+
+            Ok(schema)
         }
         #[cfg(not(feature = "remote"))]
         {
@@ -573,6 +658,21 @@ mod tests {
 
     #[test]
     fn detect_direction_request() {
+        // JSONRPC request: meta.profile at root (NOT ucp.meta.profile)
+        let payload = json!({
+            "meta": {
+                "profile": "https://example.com/.well-known/ucp"
+            },
+            "checkout": {
+                "line_items": []
+            }
+        });
+        assert_eq!(detect_direction(&payload), Some(DetectedDirection::Request));
+    }
+
+    #[test]
+    fn detect_direction_old_request_format_not_detected() {
+        // Old invalid format should NOT be detected as request
         let payload = json!({
             "ucp": {
                 "meta": {
@@ -580,7 +680,7 @@ mod tests {
                 }
             }
         });
-        assert_eq!(detect_direction(&payload), Some(DetectedDirection::Request));
+        assert_eq!(detect_direction(&payload), None);
     }
 
     #[test]
@@ -902,5 +1002,55 @@ mod tests {
             &cap_map,
             "dev.ucp.shopping.checkout"
         ));
+    }
+
+    #[test]
+    fn capability_short_name_extracts_last_segment() {
+        assert_eq!(
+            capability_short_name("dev.ucp.shopping.checkout"),
+            "checkout"
+        );
+        assert_eq!(
+            capability_short_name("dev.ucp.shopping.discount"),
+            "discount"
+        );
+        assert_eq!(capability_short_name("checkout"), "checkout");
+    }
+
+    #[test]
+    fn extract_jsonrpc_payload_finds_checkout_key() {
+        let envelope = json!({
+            "meta": {"profile": "https://example.com/profile"},
+            "checkout": {"line_items": [{"item": {"id": "sku"}, "quantity": 2}]}
+        });
+
+        let capabilities = vec![Capability {
+            name: "dev.ucp.shopping.checkout".to_string(),
+            version: "2026-01-26".to_string(),
+            schema_url: "https://example.com/checkout.json".to_string(),
+            extends: None,
+        }];
+
+        let (payload, key) = extract_jsonrpc_payload(&envelope, &capabilities).unwrap();
+        assert_eq!(key, "checkout");
+        assert_eq!(payload["line_items"][0]["quantity"], 2);
+    }
+
+    #[test]
+    fn extract_jsonrpc_payload_missing_key_errors() {
+        let envelope = json!({
+            "meta": {"profile": "https://example.com/profile"},
+            "wrong_key": {"line_items": []}
+        });
+
+        let capabilities = vec![Capability {
+            name: "dev.ucp.shopping.checkout".to_string(),
+            version: "2026-01-26".to_string(),
+            schema_url: "https://example.com/checkout.json".to_string(),
+            extends: None,
+        }];
+
+        let result = extract_jsonrpc_payload(&envelope, &capabilities);
+        assert!(matches!(result, Err(ComposeError::InvalidEnvelope { .. })));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,11 +6,14 @@ use thiserror::Error;
 /// Errors during schema composition from UCP capability metadata.
 #[derive(Debug, Error)]
 pub enum ComposeError {
-    #[error("payload is not self-describing: missing ucp.capabilities and ucp.meta.profile")]
+    #[error("payload is not self-describing: missing ucp.capabilities (response) or meta.profile (request)")]
     NotSelfDescribing,
 
     #[error("no capabilities declared in ucp.capabilities")]
     EmptyCapabilities,
+
+    #[error("invalid JSONRPC envelope: {message}")]
+    InvalidEnvelope { message: String },
 
     #[error("no root capability found (all capabilities have 'extends')")]
     NoRootCapability,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,18 +63,19 @@ mod types;
 mod validator;
 
 pub use compose::{
-    compose_from_payload, compose_schema, detect_direction, extract_capabilities, Capability,
+    capability_short_name, compose_from_payload, compose_schema, detect_direction,
+    extract_capabilities, extract_capabilities_from_profile, extract_jsonrpc_payload, Capability,
     DetectedDirection, SchemaBaseConfig,
 };
 pub use error::{ComposeError, ResolveError, SchemaError, ValidateError};
 pub use linter::{lint, lint_file, Diagnostic, FileResult, FileStatus, LintResult, Severity};
 pub use loader::{
-    bundle_refs, bundle_refs_with_url_mapping, load_schema, load_schema_auto, load_schema_str,
-    navigate_fragment,
+    bundle_refs, bundle_refs_with_url_mapping, is_url, load_schema, load_schema_auto,
+    load_schema_str, navigate_fragment,
 };
 pub use resolver::{resolve, strip_annotations};
 pub use types::{Direction, ResolveOptions, Visibility};
 pub use validator::{validate, validate_against_schema};
 
 #[cfg(feature = "remote")]
-pub use loader::load_schema_url;
+pub use loader::{bundle_refs_remote, load_schema_url};

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -316,7 +316,12 @@ fn resolve_ref_to_path(
 /// * `base_url` - Base URL for resolving relative refs (typically the schema's $id)
 #[cfg(feature = "remote")]
 pub fn bundle_refs_remote(schema: &mut Value, base_url: &str) -> Result<(), ResolveError> {
-    bundle_refs_remote_inner(schema, base_url, None, &mut std::collections::HashSet::new())
+    bundle_refs_remote_inner(
+        schema,
+        base_url,
+        None,
+        &mut std::collections::HashSet::new(),
+    )
 }
 
 #[cfg(feature = "remote")]

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -305,6 +305,118 @@ fn resolve_ref_to_path(
     base_dir.join(ref_val)
 }
 
+/// Bundle external $ref pointers by fetching from remote URLs.
+///
+/// Like `bundle_refs`, but fetches external refs via HTTP instead of local files.
+/// This allows remote-only validation by inlining all refs before passing to
+/// the JSON Schema validator.
+///
+/// # Arguments
+/// * `schema` - The schema to process (modified in place)
+/// * `base_url` - Base URL for resolving relative refs (typically the schema's $id)
+#[cfg(feature = "remote")]
+pub fn bundle_refs_remote(schema: &mut Value, base_url: &str) -> Result<(), ResolveError> {
+    bundle_refs_remote_inner(schema, base_url, None, &mut std::collections::HashSet::new())
+}
+
+#[cfg(feature = "remote")]
+fn bundle_refs_remote_inner(
+    schema: &mut Value,
+    base_url: &str,
+    file_root: Option<&Value>,
+    visited: &mut std::collections::HashSet<String>,
+) -> Result<(), ResolveError> {
+    match schema {
+        Value::Object(obj) => {
+            if let Some(ref_val) = obj.get("$ref").and_then(|v| v.as_str()) {
+                if ref_val.starts_with('#') {
+                    // Internal ref
+                    if ref_val == "#" {
+                        // Self-reference, leave as-is
+                    } else if let Some(root) = file_root {
+                        let mut target = navigate_fragment(root, ref_val)?;
+                        bundle_refs_remote_inner(&mut target, base_url, file_root, visited)?;
+                        obj.remove("$ref");
+                        if let Value::Object(ref_obj) = target {
+                            for (k, v) in ref_obj {
+                                obj.entry(k).or_insert(v);
+                            }
+                        }
+                        return Ok(());
+                    }
+                    // No file_root = root schema, leave for validator
+                } else {
+                    // External ref - resolve URL
+                    let (file_part, fragment) = match ref_val.find('#') {
+                        Some(idx) => (&ref_val[..idx], Some(&ref_val[idx..])),
+                        None => (ref_val, None),
+                    };
+
+                    // Resolve to absolute URL
+                    let resolved_url = resolve_url(file_part, base_url);
+                    let visit_key = format!("{}|{}", resolved_url, fragment.unwrap_or(""));
+
+                    if visited.contains(&visit_key) {
+                        return Err(ResolveError::BundleError {
+                            message: format!("circular reference detected: {}", ref_val),
+                        });
+                    }
+
+                    // Fetch the referenced schema
+                    let loaded = load_schema_url(&resolved_url)?;
+                    let mut target = if let Some(frag) = fragment {
+                        navigate_fragment(&loaded, frag)?
+                    } else {
+                        loaded.clone()
+                    };
+
+                    visited.insert(visit_key.clone());
+                    // Recursively bundle with new base URL
+                    bundle_refs_remote_inner(&mut target, &resolved_url, Some(&loaded), visited)?;
+                    visited.remove(&visit_key);
+
+                    obj.remove("$ref");
+                    if let Value::Object(ref_obj) = target {
+                        for (k, v) in ref_obj {
+                            obj.entry(k).or_insert(v);
+                        }
+                    }
+                    return Ok(());
+                }
+            }
+
+            // Recurse into all values
+            for value in obj.values_mut() {
+                bundle_refs_remote_inner(value, base_url, file_root, visited)?;
+            }
+        }
+        Value::Array(arr) => {
+            for item in arr {
+                bundle_refs_remote_inner(item, base_url, file_root, visited)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Resolve a potentially relative URL against a base URL.
+#[cfg(feature = "remote")]
+fn resolve_url(url: &str, base: &str) -> String {
+    if is_url(url) {
+        // Already absolute
+        url.to_string()
+    } else {
+        // Relative - resolve against base
+        // Find the directory part of base URL
+        if let Some(idx) = base.rfind('/') {
+            format!("{}/{}", &base[..idx], url)
+        } else {
+            url.to_string()
+        }
+    }
+}
+
 /// Load a schema from a file path or URL.
 ///
 /// Automatically detects whether the source is a URL or file path.

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -45,9 +45,8 @@ fn close_additional_properties(value: &mut Value) {
 fn close_additional_properties_inner(value: &mut Value, in_composition_branch: bool) {
     if let Value::Object(map) = value {
         // Check if this schema uses composition keywords
-        let has_composition = map.contains_key("allOf")
-            || map.contains_key("anyOf")
-            || map.contains_key("oneOf");
+        let has_composition =
+            map.contains_key("allOf") || map.contains_key("anyOf") || map.contains_key("oneOf");
 
         // Check if this is an object schema (has "type": "object" or has "properties")
         let is_object_schema = map

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -25,13 +25,30 @@ pub fn resolve(schema: &Value, options: &ResolveOptions) -> Result<Value, Resolv
     Ok(resolved)
 }
 
-/// Recursively set `additionalProperties: false` on all object schemas.
+/// Recursively close object schemas to reject unknown properties.
 ///
-/// Only sets the value if `additionalProperties` is missing or explicitly `true`.
-/// If a schema has `additionalProperties` set to a custom schema (object),
-/// it's left untouched since the author explicitly defined what's allowed.
+/// For simple object schemas: sets `additionalProperties: false`
+/// For schemas with composition (allOf/anyOf/oneOf): sets `unevaluatedProperties: false`
+///
+/// The distinction matters because `additionalProperties` is evaluated per-schema,
+/// while `unevaluatedProperties` (JSON Schema 2020-12) looks across all subschemas.
+/// This allows $ref inheritance patterns to work correctly in strict mode.
 fn close_additional_properties(value: &mut Value) {
+    close_additional_properties_inner(value, false);
+}
+
+/// Inner implementation with context tracking.
+///
+/// `in_composition_branch` is true when processing direct children of allOf/anyOf/oneOf.
+/// We skip setting additionalProperties on these because each branch is validated
+/// independently and doesn't see properties from sibling branches.
+fn close_additional_properties_inner(value: &mut Value, in_composition_branch: bool) {
     if let Value::Object(map) = value {
+        // Check if this schema uses composition keywords
+        let has_composition = map.contains_key("allOf")
+            || map.contains_key("anyOf")
+            || map.contains_key("oneOf");
+
         // Check if this is an object schema (has "type": "object" or has "properties")
         let is_object_schema = map
             .get("type")
@@ -40,18 +57,31 @@ fn close_additional_properties(value: &mut Value) {
             .unwrap_or(false)
             || map.contains_key("properties");
 
-        if is_object_schema {
-            // Only inject false if additionalProperties is missing or true
-            // Leave custom schemas (objects) alone - author knows what they want
-            match map.get("additionalProperties") {
-                None => {
-                    map.insert("additionalProperties".to_string(), Value::Bool(false));
+        // Close the schema if we're not inside a composition branch
+        if !in_composition_branch && (is_object_schema || has_composition) {
+            if has_composition {
+                // Use unevaluatedProperties for composition - it looks across all subschemas
+                // so $ref inheritance works correctly
+                match map.get("unevaluatedProperties") {
+                    None => {
+                        map.insert("unevaluatedProperties".to_string(), Value::Bool(false));
+                    }
+                    Some(Value::Bool(true)) => {
+                        map.insert("unevaluatedProperties".to_string(), Value::Bool(false));
+                    }
+                    _ => {}
                 }
-                Some(Value::Bool(true)) => {
-                    map.insert("additionalProperties".to_string(), Value::Bool(false));
+            } else {
+                // Simple object schema - use additionalProperties
+                match map.get("additionalProperties") {
+                    None => {
+                        map.insert("additionalProperties".to_string(), Value::Bool(false));
+                    }
+                    Some(Value::Bool(true)) => {
+                        map.insert("additionalProperties".to_string(), Value::Bool(false));
+                    }
+                    _ => {}
                 }
-                // false or custom schema - leave as-is
-                _ => {}
             }
         }
 
@@ -62,27 +92,28 @@ fn close_additional_properties(value: &mut Value) {
                     // Recurse into each property definition
                     if let Value::Object(props) = child {
                         for prop_value in props.values_mut() {
-                            close_additional_properties(prop_value);
+                            close_additional_properties_inner(prop_value, false);
                         }
                     }
                 }
-                "items" | "additionalProperties" => {
+                "items" | "additionalProperties" | "unevaluatedProperties" => {
                     // Schema values - recurse
-                    close_additional_properties(child);
+                    close_additional_properties_inner(child, false);
                 }
                 "$defs" | "definitions" => {
                     // Definitions - recurse into each
                     if let Value::Object(defs) = child {
                         for def_value in defs.values_mut() {
-                            close_additional_properties(def_value);
+                            close_additional_properties_inner(def_value, false);
                         }
                     }
                 }
                 "allOf" | "anyOf" | "oneOf" => {
-                    // Composition - recurse into each branch
+                    // Composition branches - recurse but mark as in_composition
+                    // so we don't set additionalProperties on them directly
                     if let Value::Array(arr) = child {
                         for item in arr {
-                            close_additional_properties(item);
+                            close_additional_properties_inner(item, true);
                         }
                     }
                 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -170,7 +170,10 @@ mod tests {
         let options = ResolveOptions::new(Direction::Request, "create").strict(true);
 
         let result = validate(&schema, &payload, &options);
-        assert!(result.is_ok(), "should accept properties from all allOf branches");
+        assert!(
+            result.is_ok(),
+            "should accept properties from all allOf branches"
+        );
     }
 
     #[test]
@@ -227,6 +230,9 @@ mod tests {
         let options = ResolveOptions::new(Direction::Request, "create").strict(false);
 
         let result = validate(&schema, &payload, &options);
-        assert!(result.is_ok(), "should allow unknown properties in non-strict mode");
+        assert!(
+            result.is_ok(),
+            "should allow unknown properties in non-strict mode"
+        );
     }
 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -144,4 +144,89 @@ mod tests {
             _ => panic!("expected validation error with 2 errors"),
         }
     }
+
+    #[test]
+    fn validate_allof_strict_accepts_properties_from_all_branches() {
+        // allOf with strict mode should accept properties defined in ANY branch
+        // This tests that unevaluatedProperties correctly sees all branch properties
+        let schema = json!({
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" }
+                    }
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    }
+                }
+            ]
+        });
+        // Payload uses properties from BOTH branches
+        let payload = json!({ "id": "123", "name": "test" });
+        let options = ResolveOptions::new(Direction::Request, "create").strict(true);
+
+        let result = validate(&schema, &payload, &options);
+        assert!(result.is_ok(), "should accept properties from all allOf branches");
+    }
+
+    #[test]
+    fn validate_allof_strict_rejects_unknown_properties() {
+        // allOf with strict mode should reject properties not in ANY branch
+        let schema = json!({
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" }
+                    }
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    }
+                }
+            ]
+        });
+        // Payload has unknown property
+        let payload = json!({ "id": "123", "name": "test", "unknown": "bad" });
+        let options = ResolveOptions::new(Direction::Request, "create").strict(true);
+
+        let result = validate(&schema, &payload, &options);
+        assert!(
+            matches!(result, Err(ValidateError::Invalid { .. })),
+            "should reject unknown properties in strict mode"
+        );
+    }
+
+    #[test]
+    fn validate_allof_non_strict_allows_unknown_properties() {
+        // allOf without strict mode should allow unknown properties (extensibility)
+        let schema = json!({
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" }
+                    }
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    }
+                }
+            ]
+        });
+        // Payload has unknown property
+        let payload = json!({ "id": "123", "name": "test", "unknown": "allowed" });
+        let options = ResolveOptions::new(Direction::Request, "create").strict(false);
+
+        let result = validate(&schema, &payload, &options);
+        assert!(result.is_ok(), "should allow unknown properties in non-strict mode");
+    }
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -424,7 +424,7 @@ mod validate_command {
             .assert()
             .code(3)
             .stdout(predicate::str::contains(r#""valid":false"#))
-            .stdout(predicate::str::contains(r#""error":"#));
+            .stdout(predicate::str::contains(r#""errors":"#));
     }
 }
 
@@ -1343,6 +1343,6 @@ mod compose {
             .assert()
             .code(2)
             .stdout(predicate::str::contains(r#""valid":false"#))
-            .stdout(predicate::str::contains(r#""error":"#));
+            .stdout(predicate::str::contains(r#""errors":"#));
     }
 }


### PR DESCRIPTION
 UCP defines two request patterns that differ in how the profile URL and payload are transported:

>  JSONRPC pattern: Profile URL in meta.profile, payload nested under
>  capability short name (e.g., "checkout" for dev.ucp.shopping.checkout).
>  The validator extracts the nested payload and validates it against the
>  composed schema from the profile.

>  REST pattern: Profile URL passed via HTTP header (simulated with
>  --profile CLI flag), payload is the raw object with no envelope. This
>  pattern is common for HTTP APIs where metadata travels in headers.

  - Add --profile flag to validate command for REST-style validation
  - Add extract_jsonrpc_payload() to pull payload from JSONRPC envelope
  - Add extract_capabilities_from_profile() for explicit profile loading
  - Fix direction detection: meta.profile is at root, not ucp.meta.profile

## Remote schema bundling:
  - Add bundle_refs_remote() to inline $refs from HTTP-fetched schemas
  - resolve_schema_url() now bundles remote refs after fetching
  - Enables full remote-only validation without local schema copies

## Fix strict mode fix for allOf inheritance:
The strict mode was incorrectly setting additionalProperties: false on `allOf` branches. This breaks inheritance because each branch is validated independently - branch A doesn't see properties defined in branch B, so both reject properties from the other.

Now using `unevaluatedProperties: false` at the composition level instead. JSON Schema 2020-12's unevaluatedProperties looks across all subschemas, correctly allowing properties from any branch while still rejecting truly unknown properties.