### PR TITLE
Introduce deprecated annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,6 @@ Annotations are stripped; output is standard JSON Schema.
 | `"optional"`                                                            | Field kept           | Field removed            |
 | (no annotation)                                                         | Field kept           | Unchanged                |
 | `{ "transition": { "from", "to", "description" } }` (schema transition) | Matches `from` value | Matches `from` value     |
-| (no annotation)                                                         | Field kept           | Unchanged                |
 
 Annotations can be **shorthand** (all operations) or **per-operation**, and request/response are independent:
 

--- a/README.md
+++ b/README.md
@@ -258,14 +258,14 @@ Annotations are stripped; output is standard JSON Schema.
 
 **Resolution rules:**
 
-| Value           | Effect on Properties | Effect on Required Array |
-| --------------- | -------------------- | ------------------------ |
-| `"omit"`        | Field removed        | Field removed            |
-| `"required"`    | Field kept           | Field added              |
-| `"optional"`    | Field kept           | Field removed            |
-| (no annotation) | Field kept           | Unchanged                |
-| `{ "transition": { "from", "to", "description" } }` (schema transition) | Matches `from` value | Matches `from` value |
-| (no annotation) | Field kept | Unchanged |
+| Value                                                                   | Effect on Properties | Effect on Required Array |
+| ----------------------------------------------------------------------- | -------------------- | ------------------------ |
+| `"omit"`                                                                | Field removed        | Field removed            |
+| `"required"`                                                            | Field kept           | Field added              |
+| `"optional"`                                                            | Field kept           | Field removed            |
+| (no annotation)                                                         | Field kept           | Unchanged                |
+| `{ "transition": { "from", "to", "description" } }` (schema transition) | Matches `from` value | Matches `from` value     |
+| (no annotation)                                                         | Field kept           | Unchanged                |
 
 Annotations can be **shorthand** (all operations) or **per-operation**, and request/response are independent:
 
@@ -323,7 +323,15 @@ During the transition period the resolved schema **uses the `from` value** as th
 **Shorthand schema transition** (same transition for all operations):
 
 ```json
-{ "ucp_request": { "transition": { "from": "required", "to": "omit", "description": "Removed in v2." } } }
+{
+  "ucp_request": {
+    "transition": {
+      "from": "required",
+      "to": "omit",
+      "description": "Removed in v2."
+    }
+  }
+}
 ```
 
 ### Schema Composition

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ Annotations are stripped; output is standard JSON Schema.
 | `"required"`    | Field kept           | Field added              |
 | `"optional"`    | Field kept           | Field removed            |
 | (no annotation) | Field kept           | Unchanged                |
+| `{ "transition": { "from", "to", "description" } }` (schema transition) | Matches `from` value | Matches `from` value |
+| (no annotation) | Field kept | Unchanged |
 
 Annotations can be **shorthand** (all operations) or **per-operation**, and request/response are independent:
 
@@ -282,6 +284,47 @@ Annotations can be **shorthand** (all operations) or **per-operation**, and requ
 ```
 
 Valid operations: `create`, `read`, `update`, `complete`.
+
+#### Schema transitions
+
+Use a **schema-transition object** to signal a field contract will change, with a human-readable reason:
+
+```json
+{
+  "transition": {
+    "from": "required",
+    "to": "omit",
+    "description": "Legacy id will be removed in v2; use resource_id instead."
+  }
+}
+```
+
+- **`from`** and **`to`** must be one of: `"omit"`, `"optional"`, `"required"`, and must be **distinct** (same value for both is invalid).
+- **`description`** is required and should explain the change and what to do instead.
+
+During the transition period the resolved schema **uses the `from` value** as the field's visibility, so previous implementers are not immediately affected. The resolver emits the schema-transition context into the output schema:
+
+- **`x-ucp-schema-transition`**: `{ "from", "to", "description" }` on the property for tooling and docs.
+- **`deprecated`: true** on the property only when the field is being **removed** (`to` is `"omit"`).
+
+**Example: Removing a required field**
+
+```json
+// Phase 1: Field is required
+{ "ucp_request": { "update": "required" } }
+
+// Phase 2: Schema transition (field stays required in resolved schema; tooling offers warnings)
+{ "ucp_request": { "update": { "transition": { "from": "required", "to": "omit", "description": "Will be removed in v2." } } } }
+
+// Phase 3: Remove
+{ "ucp_request": { "update": "omit" } }
+```
+
+**Shorthand schema transition** (same transition for all operations):
+
+```json
+{ "ucp_request": { "transition": { "from": "required", "to": "omit", "description": "Removed in v2." } } }
+```
 
 ### Schema Composition
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -92,6 +92,9 @@ pub enum ResolveError {
     #[error("unknown visibility \"{value}\" at {path}: expected omit, required, or optional")]
     UnknownVisibility { path: String, value: String },
 
+    #[error("invalid schema transition at {path}: {message}")]
+    InvalidSchemaTransition { path: String, message: String },
+
     #[error("invalid schema: {message}")]
     InvalidSchema { message: String },
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -11,7 +11,9 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::loader::{load_schema, navigate_fragment};
-use crate::types::{json_type_name, Visibility, UCP_ANNOTATIONS, VALID_OPERATIONS};
+use crate::types::{
+    is_valid_schema_transition, json_type_name, Visibility, UCP_ANNOTATIONS, VALID_OPERATIONS,
+};
 
 /// Severity level for diagnostics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -332,6 +334,12 @@ fn check_annotation_value(
             for (op, val) in map {
                 let op_path = format!("{}/{}", annotation_path, op);
 
+                // Handle shorthand transition key
+                if op == "transition" {
+                    check_transition_object(val, key, file, &op_path, diagnostics);
+                    continue;
+                }
+
                 // Warn on unknown operations
                 if !VALID_OPERATIONS.contains(&op.as_str()) {
                     diagnostics.push(Diagnostic {
@@ -348,31 +356,51 @@ fn check_annotation_value(
                 }
 
                 // Check value is valid
-                if let Value::String(s) = val {
-                    if Visibility::parse(s).is_none() {
+                match val {
+                    Value::String(s) => {
+                        if Visibility::parse(s).is_none() {
+                            diagnostics.push(Diagnostic {
+                                severity: Severity::Error,
+                                code: "E004".to_string(),
+                                file: file.to_path_buf(),
+                                path: op_path,
+                                message: format!(
+                                    "invalid {} value \"{}\": expected omit, required, or optional",
+                                    key, s
+                                ),
+                            });
+                        }
+                    }
+                    Value::Object(obj) => {
+                        // Per-operation transition: { "update": { "transition": { ... } } }
+                        if let Some(t) = obj.get("transition") {
+                            check_transition_object(t, key, file, &op_path, diagnostics);
+                        } else {
+                            diagnostics.push(Diagnostic {
+                                severity: Severity::Error,
+                                code: "E005".to_string(),
+                                file: file.to_path_buf(),
+                                path: op_path,
+                                message: format!(
+                                    "invalid {} value type: expected string or transition object, got {}",
+                                    key,
+                                ),
+                            });
+                        }
+                    }
+                    _ => {
                         diagnostics.push(Diagnostic {
                             severity: Severity::Error,
-                            code: "E004".to_string(),
+                            code: "E005".to_string(),
                             file: file.to_path_buf(),
                             path: op_path,
                             message: format!(
-                                "invalid {} value \"{}\": expected omit, required, or optional",
-                                key, s
+                                "invalid {} value type: expected string or transition object, got {}",
+                                key,
+                                json_type_name(val)
                             ),
                         });
                     }
-                } else {
-                    diagnostics.push(Diagnostic {
-                        severity: Severity::Error,
-                        code: "E005".to_string(),
-                        file: file.to_path_buf(),
-                        path: op_path,
-                        message: format!(
-                            "invalid {} value type: expected string, got {}",
-                            key,
-                            json_type_name(val)
-                        ),
-                    });
                 }
             }
         }
@@ -389,6 +417,46 @@ fn check_annotation_value(
                 ),
             });
         }
+    }
+}
+
+/// Validate a schema transition object { "from", "to", "description" }.
+fn check_transition_object(
+    value: &Value,
+    key: &str,
+    file: &Path,
+    path: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(obj) = value.as_object() else {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Error,
+            code: "E005".to_string(),
+            file: file.to_path_buf(),
+            path: path.to_string(),
+            message: format!(
+                "invalid {} transition: expected object, got {}",
+                key,
+                json_type_name(value)
+            ),
+        });
+        return;
+    };
+
+    let from = obj.get("from").and_then(|v| v.as_str()).unwrap_or("");
+    let to = obj.get("to").and_then(|v| v.as_str()).unwrap_or("");
+
+    if !is_valid_schema_transition(from, to) {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Error,
+            code: "E004".to_string(),
+            file: file.to_path_buf(),
+            path: path.to_string(),
+            message: format!(
+                "invalid {} schema transition: \"from\" ({}) and \"to\" ({}) must be distinct visibility values (omit, required, optional)",
+                key, from, to
+            ),
+        });
     }
 }
 
@@ -544,6 +612,64 @@ mod tests {
         let result = lint_file(file.path(), file.path().parent().unwrap());
         assert_eq!(result.status, FileStatus::Ok);
         assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn lint_valid_schema_transition_object() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "properties": {{
+                "legacy_id": {{
+                    "type": "string",
+                    "ucp_request": {{
+                        "update": {{
+                            "transition": {{
+                                "from": "required",
+                                "to": "omit",
+                                "description": "Will be removed in v2."
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Ok);
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn lint_invalid_schema_transition() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "properties": {{
+                "x": {{
+                    "type": "string",
+                    "ucp_request": {{
+                        "transition": {{
+                            "from": "required",
+                            "to": "required",
+                            "description": "from and to must be distinct"
+                        }}
+                    }}
+                }}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Error);
+        assert!(result.diagnostics.iter().any(|d| d.code == "E004"));
     }
 
     #[test]

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -446,7 +446,10 @@ fn check_transition_object(
 
     let from = obj.get("from").and_then(|v| v.as_str()).unwrap_or("");
     let to = obj.get("to").and_then(|v| v.as_str()).unwrap_or("");
-    let description = obj.get("description").and_then(|v| v.as_str()).unwrap_or("");
+    let description = obj
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
 
     if description.is_empty() {
         diagnostics.push(Diagnostic {

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -384,6 +384,7 @@ fn check_annotation_value(
                                 message: format!(
                                     "invalid {} value type: expected string or transition object, got {}",
                                     key,
+                                    json_type_name(val)
                                 ),
                             });
                         }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -4,7 +4,7 @@ use serde_json::{Map, Value};
 
 use crate::error::ResolveError;
 use crate::types::{
-    json_type_name, is_valid_schema_transition, Direction, ResolveOptions, SchemaTransitionInfo,
+    is_valid_schema_transition, json_type_name, Direction, ResolveOptions, SchemaTransitionInfo,
     Visibility, UCP_ANNOTATIONS,
 };
 
@@ -724,7 +724,9 @@ mod tests {
         assert!(result["properties"].get("id").is_some());
         let required = result["required"].as_array().unwrap();
         assert!(required.contains(&json!("id")));
-        let transition = result["properties"]["id"].get("x-ucp-schema-transition").unwrap();
+        let transition = result["properties"]["id"]
+            .get("x-ucp-schema-transition")
+            .unwrap();
         assert_eq!(transition["from"], "required");
         assert_eq!(transition["to"], "optional");
         assert_eq!(transition["description"], "Will become optional in v2.");
@@ -755,7 +757,9 @@ mod tests {
         assert!(result["properties"].get("id").is_some());
         let required = result["required"].as_array().unwrap();
         assert!(!required.contains(&json!("id")));
-        assert!(result["properties"]["id"].get("x-ucp-schema-transition").is_some());
+        assert!(result["properties"]["id"]
+            .get("x-ucp-schema-transition")
+            .is_some());
         assert_eq!(result["properties"]["id"]["deprecated"], true);
     }
 
@@ -790,7 +794,10 @@ mod tests {
         assert!(result["properties"].get("id").is_some());
         let required = result["required"].as_array().unwrap();
         assert!(required.contains(&json!("id")));
-        assert_eq!(result["properties"]["id"]["x-ucp-schema-transition"]["description"], "Removing in v2.");
+        assert_eq!(
+            result["properties"]["id"]["x-ucp-schema-transition"]["description"],
+            "Removing in v2."
+        );
     }
 
     #[test]

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -3,7 +3,10 @@
 use serde_json::{Map, Value};
 
 use crate::error::ResolveError;
-use crate::types::{json_type_name, Direction, ResolveOptions, Visibility, UCP_ANNOTATIONS};
+use crate::types::{
+    json_type_name, is_valid_schema_transition, Direction, ResolveOptions, SchemaTransitionInfo,
+    Visibility, UCP_ANNOTATIONS,
+};
 
 /// Resolve a schema for a specific direction and operation.
 ///
@@ -135,27 +138,36 @@ pub fn get_visibility(
     direction: Direction,
     operation: &str,
     path: &str,
-) -> Result<Visibility, ResolveError> {
+) -> Result<(Visibility, Option<SchemaTransitionInfo>), ResolveError> {
     let key = direction.annotation_key();
     let Some(annotation) = prop.get(key) else {
-        return Ok(Visibility::Include);
+        return Ok((Visibility::Include, None));
     };
 
     match annotation {
         // Shorthand: "ucp_request": "omit" - applies to all operations
-        Value::String(s) => parse_visibility_string(s, path),
+        Value::String(s) => Ok((parse_visibility_string(s, path)?, None)),
 
         // Object form: "ucp_request": { "create": "omit", "update": "required" }
         Value::Object(map) => {
             // Lookup operation (already lowercase from ResolveOptions)
             match map.get(operation) {
-                Some(Value::String(s)) => parse_visibility_string(s, path),
+                Some(Value::String(s)) => Ok((parse_visibility_string(s, path)?, None)),
+                Some(Value::Object(obj)) => {
+                    parse_transition_value(obj, &format!("{}/{}", path, operation))
+                }
                 Some(other) => Err(ResolveError::InvalidAnnotationType {
                     path: format!("{}/{}", path, operation),
                     actual: json_type_name(other).to_string(),
                 }),
-                // Operation not specified → default to include
-                None => Ok(Visibility::Include),
+                None => {
+                    // Check for shorthand transition form
+                    if let Some(Value::Object(t)) = map.get("transition") {
+                        parse_transition_value(t, path)
+                    } else {
+                        Ok((Visibility::Include, None))
+                    }
+                }
             }
         }
 
@@ -165,6 +177,46 @@ pub fn get_visibility(
             actual: json_type_name(other).to_string(),
         }),
     }
+}
+
+fn parse_transition_value(
+    obj: &Map<String, Value>,
+    path: &str,
+) -> Result<(Visibility, Option<SchemaTransitionInfo>), ResolveError> {
+    let t = obj
+        .get("transition")
+        .and_then(|v| v.as_object())
+        .unwrap_or(obj);
+
+    let from = t.get("from").and_then(|v| v.as_str()).unwrap_or("");
+    let to = t.get("to").and_then(|v| v.as_str()).unwrap_or("");
+    let description = t.get("description").and_then(|v| v.as_str()).unwrap_or("");
+
+    if description.is_empty() {
+        return Err(ResolveError::InvalidSchemaTransition {
+            path: path.to_string(),
+            message: "missing required field \"description\"".to_string(),
+        });
+    }
+    if !is_valid_schema_transition(from, to) {
+        return Err(ResolveError::InvalidSchemaTransition {
+            path: path.to_string(),
+            message: format!(
+                "\"from\" ({}) and \"to\" ({}) must be distinct visibility values",
+                from, to
+            ),
+        });
+    }
+
+    let vis = parse_visibility_string(from, path)?;
+    Ok((
+        vis,
+        Some(SchemaTransitionInfo {
+            from: from.to_string(),
+            to: to.to_string(),
+            description: description.to_string(),
+        }),
+    ))
 }
 
 /// Strip all UCP annotations from a schema.
@@ -285,7 +337,7 @@ fn resolve_properties(
         let prop_path = format!("{}/{}", path, prop_name);
 
         // Get visibility for this property
-        let visibility = get_visibility(
+        let (visibility, transition) = get_visibility(
             prop_value,
             options.direction,
             &options.operation,
@@ -300,7 +352,8 @@ fn resolve_properties(
             Visibility::Required => {
                 // Keep property, ensure in required
                 let resolved = resolve_value(prop_value, options, &prop_path)?;
-                let stripped = strip_annotations(&resolved);
+                let mut stripped = strip_annotations(&resolved);
+                apply_transition_metadata(&mut stripped, &transition);
                 result.insert(prop_name.clone(), stripped);
                 if !required.contains(prop_name) {
                     required.push(prop_name.clone());
@@ -309,14 +362,16 @@ fn resolve_properties(
             Visibility::Optional => {
                 // Keep property, remove from required
                 let resolved = resolve_value(prop_value, options, &prop_path)?;
-                let stripped = strip_annotations(&resolved);
+                let mut stripped = strip_annotations(&resolved);
+                apply_transition_metadata(&mut stripped, &transition);
                 result.insert(prop_name.clone(), stripped);
                 required.retain(|r| r != prop_name);
             }
             Visibility::Include => {
                 // Keep as-is (preserve original required status)
                 let resolved = resolve_value(prop_value, options, &prop_path)?;
-                let stripped = strip_annotations(&resolved);
+                let mut stripped = strip_annotations(&resolved);
+                apply_transition_metadata(&mut stripped, &transition);
                 result.insert(prop_name.clone(), stripped);
             }
         }
@@ -393,6 +448,22 @@ fn strip_annotations_recursive(value: &Value) -> Value {
     }
 }
 
+fn apply_transition_metadata(value: &mut Value, transition: &Option<SchemaTransitionInfo>) {
+    if let (Value::Object(map), Some(info)) = (value, transition) {
+        map.insert(
+            "x-ucp-schema-transition".to_string(),
+            serde_json::json!({
+                "from": info.from,
+                "to": info.to,
+                "description": info.description,
+            }),
+        );
+        if info.to == "omit" {
+            map.insert("deprecated".to_string(), Value::Bool(true));
+        }
+    }
+}
+
 fn parse_visibility_string(s: &str, path: &str) -> Result<Visibility, ResolveError> {
     Visibility::parse(s).ok_or_else(|| ResolveError::UnknownVisibility {
         path: path.to_string(),
@@ -413,7 +484,7 @@ mod tests {
             "type": "string",
             "ucp_request": "omit"
         });
-        let vis = get_visibility(&prop, Direction::Request, "create", "/test").unwrap();
+        let (vis, _) = get_visibility(&prop, Direction::Request, "create", "/test").unwrap();
         assert_eq!(vis, Visibility::Omit);
     }
 
@@ -423,7 +494,7 @@ mod tests {
             "type": "string",
             "ucp_request": "required"
         });
-        let vis = get_visibility(&prop, Direction::Request, "create", "/test").unwrap();
+        let (vis, _) = get_visibility(&prop, Direction::Request, "create", "/test").unwrap();
         assert_eq!(vis, Visibility::Required);
     }
 
@@ -436,11 +507,33 @@ mod tests {
                 "update": "required"
             }
         });
-        let vis = get_visibility(&prop, Direction::Request, "create", "/test").unwrap();
+        let (vis, _) = get_visibility(&prop, Direction::Request, "create", "/test").unwrap();
         assert_eq!(vis, Visibility::Omit);
 
-        let vis = get_visibility(&prop, Direction::Request, "update", "/test").unwrap();
+        let (vis, _) = get_visibility(&prop, Direction::Request, "update", "/test").unwrap();
         assert_eq!(vis, Visibility::Required);
+    }
+
+    #[test]
+    fn get_visibility_schema_transition_object() {
+        let prop = json!({
+            "type": "string",
+            "ucp_request": {
+                "update": {
+                    "transition": {
+                        "from": "required",
+                        "to": "omit",
+                        "description": "Legacy id will be removed in v2."
+                    }
+                }
+            }
+        });
+        let (vis, dep) = get_visibility(&prop, Direction::Request, "update", "/test").unwrap();
+        assert_eq!(vis, Visibility::Required);
+        let info = dep.unwrap();
+        assert_eq!(info.from, "required");
+        assert_eq!(info.to, "omit");
+        assert_eq!(info.description, "Legacy id will be removed in v2.");
     }
 
     #[test]
@@ -448,7 +541,7 @@ mod tests {
         let prop = json!({
             "type": "string"
         });
-        let vis = get_visibility(&prop, Direction::Request, "create", "/test").unwrap();
+        let (vis, _) = get_visibility(&prop, Direction::Request, "create", "/test").unwrap();
         assert_eq!(vis, Visibility::Include);
     }
 
@@ -461,7 +554,7 @@ mod tests {
             }
         });
         // "update" not in dict, should default to include
-        let vis = get_visibility(&prop, Direction::Request, "update", "/test").unwrap();
+        let (vis, _) = get_visibility(&prop, Direction::Request, "update", "/test").unwrap();
         assert_eq!(vis, Visibility::Include);
     }
 
@@ -471,11 +564,11 @@ mod tests {
             "type": "string",
             "ucp_response": "omit"
         });
-        let vis = get_visibility(&prop, Direction::Response, "create", "/test").unwrap();
+        let (vis, _) = get_visibility(&prop, Direction::Response, "create", "/test").unwrap();
         assert_eq!(vis, Visibility::Omit);
 
         // Request direction should see include (no ucp_request annotation)
-        let vis = get_visibility(&prop, Direction::Request, "create", "/test").unwrap();
+        let (vis, _) = get_visibility(&prop, Direction::Request, "create", "/test").unwrap();
         assert_eq!(vis, Visibility::Include);
     }
 
@@ -517,6 +610,26 @@ mod tests {
         assert!(matches!(
             result,
             Err(ResolveError::UnknownVisibility { value, .. }) if value == "maybe"
+        ));
+    }
+
+    #[test]
+    fn get_visibility_invalid_schema_transition_errors() {
+        let prop = json!({
+            "type": "string",
+            "ucp_request": {
+                "update": {
+                    "transition": {
+                        "from": "required",
+                        "to": "omit"
+                    }
+                }
+            }
+        });
+        let result = get_visibility(&prop, Direction::Request, "update", "/test");
+        assert!(matches!(
+            result,
+            Err(ResolveError::InvalidSchemaTransition { .. })
         ));
     }
 
@@ -585,6 +698,99 @@ mod tests {
 
         let required = result["required"].as_array().unwrap();
         assert!(!required.contains(&json!("id")));
+    }
+
+    #[test]
+    fn resolve_schema_transition_emits_transition_info() {
+        let schema = json!({
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "ucp_request": {
+                        "transition": {
+                            "from": "required",
+                            "to": "optional",
+                            "description": "Will become optional in v2."
+                        }
+                    }
+                }
+            }
+        });
+        let options = ResolveOptions::new(Direction::Request, "create");
+        let result = resolve(&schema, &options).unwrap();
+
+        assert!(result["properties"].get("id").is_some());
+        let required = result["required"].as_array().unwrap();
+        assert!(required.contains(&json!("id")));
+        let transition = result["properties"]["id"].get("x-ucp-schema-transition").unwrap();
+        assert_eq!(transition["from"], "required");
+        assert_eq!(transition["to"], "optional");
+        assert_eq!(transition["description"], "Will become optional in v2.");
+        assert!(result["properties"]["id"].get("deprecated").is_none());
+    }
+
+    #[test]
+    fn resolve_schema_transition_sets_deprecated_when_to_omit() {
+        let schema = json!({
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "ucp_request": {
+                        "transition": {
+                            "from": "optional",
+                            "to": "omit",
+                            "description": "Will be removed in v2."
+                        }
+                    }
+                }
+            }
+        });
+        let options = ResolveOptions::new(Direction::Request, "create");
+        let result = resolve(&schema, &options).unwrap();
+
+        assert!(result["properties"].get("id").is_some());
+        let required = result["required"].as_array().unwrap();
+        assert!(!required.contains(&json!("id")));
+        assert!(result["properties"]["id"].get("x-ucp-schema-transition").is_some());
+        assert_eq!(result["properties"]["id"]["deprecated"], true);
+    }
+
+    #[test]
+    fn resolve_schema_transition_per_operation() {
+        let schema = json!({
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "ucp_request": {
+                        "create": "omit",
+                        "update": {
+                            "transition": {
+                                "from": "required",
+                                "to": "omit",
+                                "description": "Removing in v2."
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let options = ResolveOptions::new(Direction::Request, "create");
+        let result = resolve(&schema, &options).unwrap();
+        assert!(result["properties"].get("id").is_none());
+
+        let options = ResolveOptions::new(Direction::Request, "update");
+        let result = resolve(&schema, &options).unwrap();
+        assert!(result["properties"].get("id").is_some());
+        let required = result["required"].as_array().unwrap();
+        assert!(required.contains(&json!("id")));
+        assert_eq!(result["properties"]["id"]["x-ucp-schema-transition"]["description"], "Removing in v2.");
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,15 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Schema transition: from/to are visibility values (omit, optional, required).
+/// During the transition period the field is always optional in the resolved schema.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SchemaTransitionInfo {
+    pub from: String,
+    pub to: String,
+    pub description: String,
+}
+
 /// Valid UCP operations for annotation object form.
 pub const VALID_OPERATIONS: &[&str] = &["create", "update", "complete", "read"];
 
@@ -80,6 +89,14 @@ impl Visibility {
     }
 }
 
+/// Returns true if (from, to) is a valid schema transition: both are visibility
+/// values (omit, optional, required) and from != to.
+pub fn is_valid_schema_transition(from: &str, to: &str) -> bool {
+    from != to
+        && Visibility::parse(from).is_some()
+        && Visibility::parse(to).is_some()
+}
+
 /// Options for schema resolution.
 #[derive(Debug, Clone)]
 pub struct ResolveOptions {
@@ -136,6 +153,28 @@ mod tests {
         assert_eq!(Visibility::parse("include"), None);
         assert_eq!(Visibility::parse("readonly"), None);
         assert_eq!(Visibility::parse(""), None);
+    }
+
+    #[test]
+    fn valid_schema_transitions() {
+        // Any distinct pair of visibility values is valid
+        for (from, to) in [
+            ("required", "optional"),
+            ("required", "omit"),
+            ("optional", "omit"),
+            ("optional", "required"),
+            ("omit", "required"),
+            ("omit", "optional"),
+        ] {
+            assert!(super::is_valid_schema_transition(from, to));
+        }
+        // Disbarred: same value for both
+        assert!(!super::is_valid_schema_transition("required", "required"));
+        assert!(!super::is_valid_schema_transition("omit", "omit"));
+        assert!(!super::is_valid_schema_transition("optional", "optional"));
+        // Disbarred: invalid visibility value
+        assert!(!super::is_valid_schema_transition("readonly", "omit"));
+        assert!(!super::is_valid_schema_transition("required", "invalid"));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Schema transition: from/to are visibility values (omit, optional, required).
-/// During the transition period the field is always optional in the resolved schema.
+/// During the transition period the field is always the `from` visibility.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SchemaTransitionInfo {
     pub from: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -92,9 +92,7 @@ impl Visibility {
 /// Returns true if (from, to) is a valid schema transition: both are visibility
 /// values (omit, optional, required) and from != to.
 pub fn is_valid_schema_transition(from: &str, to: &str) -> bool {
-    from != to
-        && Visibility::parse(from).is_some()
-        && Visibility::parse(to).is_some()
+    from != to && Visibility::parse(from).is_some() && Visibility::parse(to).is_some()
 }
 
 /// Options for schema resolution.


### PR DESCRIPTION
# Description

Adds first-class support for field deprecation with explicit schema transition semantics. This enables schema authors to signal upcoming breaking changes while attempting to preserve backwards compatibility during the transition period.

The schema now adds "deprecated" for transitions to "omit" visibility, and a x-ucp-schema-transition field to express the upcoming changes in an expressive way inside each schema object.

### Examples
#### Required -> Optional
Input:
```
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "type": "object",
  "required": ["id", "name"],
  "properties": {
    "id": {
      "type": "string",
      "ucp_request": {
        "update": {
          "from": "required",
          "to": "optional",
          "description": "Will become optional in v2."
        }
      }
    },
    "name": { "type": "string" }
  }
}
```

Output:
```
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "type": "object",
  "properties": {
    "id": {
      "type": "string",
      "x-ucp-schema-transition": {
        "from": "required",
        "to": "optional",
        "description": "Will become optional in v2."
      }
    },
    "name": {
      "type": "string"
    }
  },
  "required": [
    "name"
  ]
}
```

#### Required -> Omit
Input:
```
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "type": "object",
  "required": ["id", "name"],
  "properties": {
    "id": {
      "type": "string",
      "ucp_request": {
        "update": {
          "from": "required",
          "to": "omit",
          "description": "Legacy id will be removed in v2; use resource_id instead."
        }
      }
    },
    "name": { "type": "string" }
  }
}
```

Output: 
```
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "type": "object",
  "properties": {
    "id": {
      "type": "string",
      "x-ucp-schema-transition": {
        "from": "required",
        "to": "omit",
        "description": "Legacy id will be removed in v2; use resource_id instead."
      },
      "deprecated": true
    },
    "name": {
      "type": "string"
    }
  },
  "required": [
    "name"
  ]
}
```

## Motivation

When evolving APIs, transitions like `required → optional` or `required → omit` are breaking changes that affect different parties:
- Loosening (`required → optional`): Receivers must update to handle absence
- Tightening (`optional → required`): Senders must update to always include the field
- Removal: Both parties need to adapt

Previously, there was no way to express "this field is currently required but will be removed" in a machine-readable way.
## Changes

Introduces schema-transitions object which describes the current state, the future state, and a description for the change. Readme describes the expectation for implementation based on each valid transition. Each transitioning visibility is treated as optional while between states, allowing the sender and receiver of each request to properly handle absence without typing errors (someone is always looser than the other).

The concern here: even introducing a schema-transition WILL ALWAYS BE BREAKING because the schema itself will have to loosen in a breaking way for at least one party. Each of businesses or platforms will have to re-parse the output schema state based on the x-ucp tag to identify what fields should or should not be required, optional, or omitted for them truthfully in a version.

## Why do we need more than a simple "deprecated" field? Why do we have states?

UCP annotations are symmetrical by default between the sender and receiver; we are introducing integration burdens on just one party for a given request/response (i.e. sender of request, please start ALWAYS sending it as its becoming required, or receiver of this response, stop expecting it even though it was required).