### PR TITLE
chore: add pre-commit configuration and style CI

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,3 +1,17 @@
+#   Copyright 2026 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 name: Lint
 
 on:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2026 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 exclude: '^(\.github/|\.vscode/|node_modules/).*|CODE_OF_CONDUCT\.md|CHANGELOG\.md'
 
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+exclude: '^(\.github/|\.vscode/|node_modules/).*|CODE_OF_CONDUCT\.md|CHANGELOG\.md'
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+        args: [--unsafe]
+    -   id: check-json
+    -   id: check-added-large-files
+    -   id: detect-private-key
+    -   id: check-shebang-scripts-are-executable
+    -   id: check-executables-have-shebangs
+-   repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+    -   id: prettier
+        files: \.(json|md|yaml|yml)$
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    -   id: fmt
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+    -   id: codespell
+        args: ["--skip", "Cargo.lock"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,29 +15,29 @@
 exclude: '^(\.github/|\.vscode/|node_modules/).*|CODE_OF_CONDUCT\.md|CHANGELOG\.md'
 
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
         args: [--unsafe]
-    -   id: check-json
-    -   id: check-added-large-files
-    -   id: detect-private-key
-    -   id: check-shebang-scripts-are-executable
-    -   id: check-executables-have-shebangs
--   repo: https://github.com/pre-commit/mirrors-prettier
+      - id: check-json
+      - id: check-added-large-files
+      - id: detect-private-key
+      - id: check-shebang-scripts-are-executable
+      - id: check-executables-have-shebangs
+  - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:
-    -   id: prettier
+      - id: prettier
         files: \.(json|md|yaml|yml)$
--   repo: https://github.com/doublify/pre-commit-rust
+  - repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0
     hooks:
-    -   id: fmt
--   repo: https://github.com/codespell-project/codespell
+      - id: fmt
+  - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:
-    -   id: codespell
+      - id: codespell
         args: ["--skip", "Cargo.lock"]


### PR DESCRIPTION
Description


  This PR introduces the pre-commit configuration and CI workflow to ucp-schema. It complements the
  existing Rust CI by adding coverage for non-Rust files (JSON, YAML, Markdown) and repository hygiene.

  Type of change


   - [x] New feature (non-breaking change which adds functionality)

  ---

  Is this a Breaking Change or Removal?

   - [x] No

  ---

  Checklist


   - [x] My code follows the style guidelines of this project
   - [x] I have performed a self-review of my own code
   - [x] My changes generate no new warnings