### PR TITLE
feat: expose compose > resolve > validate pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /local
+node_modules/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +235,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "core-foundation"
@@ -520,6 +539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +558,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -799,6 +825,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +860,31 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -992,6 +1052,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -1077,6 +1169,44 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "ref-cast"
@@ -1264,6 +1394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1483,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -1498,6 +1640,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
@@ -1613,6 +1756,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "jsonschema",
+ "mockito",
  "predicates",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,6 @@ remote = ["reqwest"]
 
 [dev-dependencies]
 assert_cmd = "2"
+mockito = "1.7.2"
 predicates = "3"
 tempfile = "3"

--- a/FAQ.md
+++ b/FAQ.md
@@ -24,11 +24,11 @@ Use `--strict` only when you need a closed contract:
 
 **They're different validation modes:**
 
-| Flag                          | Mode                    | Schema source                               |
-| ----------------------------- | ----------------------- | ------------------------------------------- |
-| (none)                        | Self-describing         | Fetches URLs from `ucp.capabilities`        |
-| `--schema-local-base ./dir`   | Self-describing + local | Maps capability URLs to local files         |
-| `--schema file.json`          | Explicit                | Uses specified schema, ignores capabilities |
+| Flag                        | Mode                    | Schema source                               |
+| --------------------------- | ----------------------- | ------------------------------------------- |
+| (none)                      | Self-describing         | Fetches URLs from `ucp.capabilities`        |
+| `--schema-local-base ./dir` | Self-describing + local | Maps capability URLs to local files         |
+| `--schema file.json`        | Explicit                | Uses specified schema, ignores capabilities |
 
 `--schema-local-base` is useful for:
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -13,24 +13,24 @@ This is intentional:
 
 If a payload has `{ "id": "123", "custom_field": "foo" }` and the schema only defines `id`, validation passes. The `custom_field` is ignored—not rejected.
 
-Use `--strict=true` only when you need a closed contract:
+Use `--strict` only when you need a closed contract:
 
 - Catching field name typos during development
 - Systems where the schema is the complete specification
 
 ---
 
-## What's the difference between `--schema` and `--schema-base`?
+## What's the difference between `--schema` and `--schema-local-base`?
 
 **They're different validation modes:**
 
-| Flag                  | Mode                    | Schema source                               |
-| --------------------- | ----------------------- | ------------------------------------------- |
-| (none)                | Self-describing         | Fetches URLs from `ucp.capabilities`        |
-| `--schema-base ./dir` | Self-describing + local | Maps capability URLs to local files         |
-| `--schema file.json`  | Explicit                | Uses specified schema, ignores capabilities |
+| Flag                          | Mode                    | Schema source                               |
+| ----------------------------- | ----------------------- | ------------------------------------------- |
+| (none)                        | Self-describing         | Fetches URLs from `ucp.capabilities`        |
+| `--schema-local-base ./dir`   | Self-describing + local | Maps capability URLs to local files         |
+| `--schema file.json`          | Explicit                | Uses specified schema, ignores capabilities |
 
-`--schema-base` is useful for:
+`--schema-local-base` is useful for:
 
 - Offline testing
 - Local development before publishing schemas
@@ -38,10 +38,10 @@ Use `--strict=true` only when you need a closed contract:
 
 **How it works:** The flag extracts the URL path and maps it to a local file. This works for any domain—not just `ucp.dev`:
 
-| Schema URL                                       | Local path (`--schema-base ./local`)     |
-| ------------------------------------------------ | ---------------------------------------- |
-| `https://ucp.dev/schemas/shopping/checkout.json` | `./local/schemas/shopping/checkout.json` |
-| `https://extensions.3p.com/schemas/loyalty.json` | `./local/schemas/loyalty.json`           |
+| Schema URL                                       | Local path (`--schema-local-base ./local`) |
+| ------------------------------------------------ | ------------------------------------------ |
+| `https://ucp.dev/schemas/shopping/checkout.json` | `./local/schemas/shopping/checkout.json`   |
+| `https://extensions.3p.com/schemas/loyalty.json` | `./local/schemas/loyalty.json`             |
 
 This means you can develop and test third-party extensions locally before publishing.
 
@@ -54,10 +54,10 @@ This means you can develop and test third-party extensions locally before publis
 | Payload has        | Detected direction                               |
 | ------------------ | ------------------------------------------------ |
 | `ucp.capabilities` | Response                                         |
-| `ucp.meta.profile` | Request                                          |
+| `meta.profile`     | Request                                          |
 | Neither            | Error (must specify `--request` or `--response`) |
 
-This only applies to `validate`. The `resolve` command always requires explicit `--request` or `--response`.
+This applies to both `validate` and `resolve` when the input is a self-describing payload. When resolving a plain schema file, explicit `--request` or `--response` is required.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,35 @@
 # ucp-schema
 
-CLI and library for working with UCP-annotated JSON Schemas.
+CLI and library for [Universal Commerce Protocol](https://ucp.dev) (UCP) schemas.
 
-UCP schemas use `ucp_request` and `ucp_response` annotations to define field visibility per operation. This tool resolves those annotations into standard JSON Schema, letting you validate payloads for specific operations (create, read, update, etc.).
+UCP defines an open extensibility protocol on top of JSON Schema. Agents negotiate capabilities at runtime via self-describing payloads, extensions compose dynamically via `allOf`, and `ucp_request`/`ucp_response` annotations control field visibility per direction and operation. This tool implements UCP's composition and resolution pipeline: compose capability schemas, resolve annotations into standard JSON Schema, and validate payloads.
+
+## How It Works
+
+The CLI exposes a progressive pipeline. Each command runs it up to its named step:
+
+```
+  ┌───────────────────┐     ┌───────────────────┐     ┌───────────────────┐
+  │      compose      │ ──▶ │      resolve      │ ──▶ │     validate      │
+  └───────────────────┘     └───────────────────┘     └───────────────────┘
+   merge capability          apply annotations           check payload
+   schemas into one          for direction + op           against schema
+```
+
+Like `gcc -E` (preprocess only) vs `gcc` (full build), each command runs the pipeline to a different depth: `compose` stops after merging capability schemas, `resolve` applies annotations, and `validate` runs through to payload checking. When the input is a self-describing payload, earlier stages run automatically. `lint` is independent static analysis.
+
+For example, a field annotated with `"ucp_request": {"create": "omit", "update": "required"}` disappears from create schemas but becomes required on update — one source schema, different views per operation. See [Visibility Rules](#visibility-rules) for the full worked example.
+
+**"I want to..."**
+
+| Goal | Command |
+|------|---------|
+| Inspect the composed schema (annotations preserved) | `compose payload.json --schema-local-base ./schemas --pretty` |
+| Get JSON Schema for an operation | `resolve payload.json --op read --schema-local-base ./schemas` |
+| Resolve a single schema file (no composition) | `resolve schema.json --request --op create` |
+| Validate a payload end-to-end | `validate payload.json --op read --schema-local-base ./schemas` |
+| Check schemas for errors before runtime | `lint schemas/` |
+| Debug what the pipeline is doing | Add `--verbose` to any command |
 
 ## Installation
 
@@ -16,297 +43,114 @@ cd ucp-schema
 cargo install --path .
 ```
 
-## Quick Start
-
-Given a UCP schema where `id` is omitted on create but required on update:
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "id": {
-      "type": "string",
-      "ucp_request": { "create": "omit", "update": "required" }
-    },
-    "name": { "type": "string" }
-  }
-}
-```
-
-Resolve it for different operations:
-
-```bash
-# For create: id is removed from the schema
-ucp-schema resolve schema.json --request --op create --pretty
-
-# For update: id is required
-ucp-schema resolve schema.json --request --op update --pretty
-```
-
-Validate a payload:
-
-```bash
-# This fails - id not allowed on create
-echo '{"id": "123", "name": "test"}' > payload.json
-ucp-schema validate payload.json --schema schema.json --request --op create
-
-# This passes - id required on update
-ucp-schema validate payload.json --schema schema.json --request --op update
-```
-
 ## CLI Reference
 
-### `resolve` - Generate operation-specific schema
+### `compose` — Compose schemas from capabilities
 
-Accepts a schema file or a self-describing payload. When given a payload, automatically composes schemas from capabilities before resolving.
-
-```bash
-# Schema input (direction flag required)
-ucp-schema resolve <schema> --request|--response --op <operation> [options]
-
-# Payload input (direction auto-inferred)
-ucp-schema resolve <payload> --op <operation> --schema-local-base <dir> [options]
-
-Options:
-  --pretty                    Pretty-print JSON output
-  --bundle                    Inline all external $ref pointers (schema input only)
-  --schema-local-base <dir>   Local directory for schema resolution (payload input only)
-  --schema-remote-base <url>  URL prefix to strip when mapping to local
-  --strict=true               Reject unknown fields (default: false, see Validation)
-  --output                    Write to file instead of stdout
-  --verbose, -v               Print pipeline stages to stderr
-```
-
-Examples:
-
-```bash
-# Resolve for create request, pretty print
-ucp-schema resolve checkout.json --request --op create --pretty
-
-# Resolve for read response
-ucp-schema resolve checkout.json --response --op read
-
-# Resolve from URL
-ucp-schema resolve https://ucp.dev/schemas/checkout.json --request --op create
-
-# Save resolved schema to file
-ucp-schema resolve checkout.json --request --op create --output resolved.json
-
-# Auto-compose from payload, then resolve (direction auto-inferred)
-ucp-schema resolve response.json --op read --schema-local-base ./schemas
-
-# Debug pipeline stages
-ucp-schema resolve response.json --op read --schema-local-base ./schemas --verbose
-```
-
-### `validate` - Validate payload against resolved schema
-
-UCP payloads are self-describing: they embed capability metadata that declares which schemas apply. The validator can use this metadata directly, or you can specify an explicit schema.
-
-```bash
-# Self-describing mode (response: ucp.capabilities, JSONRPC request: meta.profile)
-ucp-schema validate <payload> --op <operation> [options]
-
-# REST request mode (profile via flag, payload is raw object)
-ucp-schema validate <payload> --profile <profile> --op <operation> [options]
-
-# Explicit schema mode (overrides self-describing)
-ucp-schema validate <payload> --schema <schema> --request|--response --op <operation> [options]
-
-Options:
-  --schema <path>              Explicit schema (overrides self-describing mode)
-  --profile <path>             Agent profile URL/path (REST request pattern)
-  --schema-local-base <dir>    Local directory to resolve schema URLs (see Validation Modes)
-  --schema-remote-base <url>   URL prefix to strip when mapping to local (see URL Prefix Mapping)
-  --request                    Direction is request (required with --schema, auto-detected otherwise)
-  --response                   Direction is response (required with --schema, auto-detected otherwise)
-  --json                       Output results as JSON (for automation)
-  --strict=true                Reject unknown fields (default: false, see Validation)
-```
-
-Exit codes:
-
-- `0` - Valid
-- `1` - Validation failed (payload doesn't match schema)
-- `2` - Schema error (invalid annotations, parse error, composition error)
-- `3` - File/network error
-
-### Validation Modes
-
-The validator supports multiple modes based on which flags you provide:
-
-| Mode                           | Command                                                            | Schema Source            | Direction     |
-| ------------------------------ | ------------------------------------------------------------------ | ------------------------ | ------------- |
-| **Response (self-describing)** | `validate response.json --op read`                                 | `ucp.capabilities` URLs  | Auto-detected |
-| **JSONRPC request**            | `validate envelope.json --op create`                               | `meta.profile` URL       | Auto-detected |
-| **REST request**               | `validate payload.json --profile profile.json --op create`         | Explicit `--profile` URL | Request       |
-| **Explicit schema**            | `validate payload.json --schema schema.json --request --op create` | Specified schema         | Must specify  |
-
-**Response Pattern (self-describing)**
-
-Response payloads embed capability metadata declaring which schemas apply:
-
-```json
-{
-  "ucp": {
-    "capabilities": {
-      "dev.ucp.shopping.checkout": [{"version": "2026-01-26", "schema": "https://..."}]
-    }
-  },
-  "id": "checkout-123",
-  "line_items": [...]
-}
-```
-
-```bash
-ucp-schema validate response.json --op read
-```
-
-**JSONRPC Request Pattern**
-
-JSONRPC requests have `meta.profile` at root, with payload nested under the capability short name:
-
-```json
-{
-  "meta": {
-    "profile": "https://agent.example.com/.well-known/ucp"
-  },
-  "checkout": {
-    "line_items": [...]
-  }
-}
-```
-
-```bash
-ucp-schema validate envelope.json --op create
-```
-
-The validator:
-
-1. Fetches the profile from `meta.profile`
-2. Extracts capabilities from the profile
-3. Extracts payload from the capability key (e.g., `checkout`)
-4. Composes and validates
-
-**REST Request Pattern (--profile flag)**
-
-REST requests pass the profile via HTTP header (simulated with `--profile`), with payload being the raw object:
-
-```bash
-# Payload is just the checkout object (no envelope)
-ucp-schema validate raw-checkout.json --profile agent-profile.json --op create
-```
-
-The `--profile` flag:
-
-- Takes a profile URL or file path
-- Extracts capabilities from the profile
-- Treats the payload as the raw checkout object (no envelope extraction)
-- Implies `--request` direction
-
-**Mode 2: Self-describing + local resolution**
-
-Same as above, but schema URLs are resolved to local files instead of fetched:
-
-```bash
-# Schema URL https://ucp.dev/schemas/shopping/checkout.json
-# Maps to: ./local/schemas/shopping/checkout.json
-ucp-schema validate response.json --schema-local-base ./local --op read
-```
-
-The `--schema-local-base` flag maps URL paths to local files:
-
-- URL: `https://ucp.dev/schemas/shopping/checkout.json`
-- Path extracted: `/schemas/shopping/checkout.json`
-- Local file: `{schema-local-base}/schemas/shopping/checkout.json`
-
-**URL Prefix Mapping**
-
-When schema URLs have versioned prefixes that don't match your local directory structure, use `--schema-remote-base` to strip the prefix:
-
-```bash
-# Schema URL: https://ucp.dev/draft/schemas/shopping/checkout.json
-# Local path: ./site/schemas/shopping/checkout.json (no "draft" directory)
-ucp-schema validate response.json \
-  --schema-local-base ./site \
-  --schema-remote-base "https://ucp.dev/draft" \
-  --op read
-```
-
-Mapping with `--schema-remote-base`:
-
-- URL: `https://ucp.dev/draft/schemas/shopping/checkout.json`
-- Strip prefix: `https://ucp.dev/draft` → `/schemas/shopping/checkout.json`
-- Local file: `{schema-local-base}/schemas/shopping/checkout.json`
-
-This is useful when published schemas have versioned `$id` URLs but your local files are organized without the version prefix.
-
-Useful for: offline testing, local development, testing schema changes before deployment.
-
-**Mode 3: Explicit schema**
-
-Bypass self-describing metadata entirely by specifying `--schema`:
-
-```bash
-# Ignores any ucp.capabilities in payload, uses specified schema
-ucp-schema validate order.json --schema checkout.json --request --op create
-
-# Works with URLs too
-ucp-schema validate order.json --schema https://ucp.dev/schemas/checkout.json --request --op create
-```
-
-Requires: explicit `--request` or `--response` flag (direction cannot be auto-detected).
-
-**Error: No schema source**
-
-If payload has no `ucp.capabilities`/`meta.profile` AND no `--schema`/`--profile` is specified:
-
-```bash
-ucp-schema validate payload.json --op read
-# Error: cannot infer direction: payload has no ucp.capabilities (response) or meta.profile (request)
-```
-
-**JSON output for automation:**
-
-```bash
-ucp-schema validate order.json --schema checkout.json --request --op create --json
-# Output: {"valid":true}
-# Or:     {"valid":false,"errors":[{"path":"","message":"..."}]}
-```
-
-### `compose` - Compose schemas from capabilities
-
-Pure composition step: merges capability schemas from a self-describing payload. Output preserves UCP annotations (no resolve step). Use this to inspect what the composed schema looks like before resolution.
+Pure composition: merges capability schemas from a self-describing payload into one schema. Output preserves UCP annotations (no resolve step).
 
 ```bash
 ucp-schema compose <payload> [options]
 
 Options:
   --schema-local-base <dir>   Local directory for schema resolution
-  --schema-remote-base <url>  URL prefix to strip when mapping to local
+  --schema-remote-base <url>  URL prefix to strip when mapping to local (see Concepts > Local Resolution)
   --pretty                    Pretty-print JSON output
-  --output                    Write to file instead of stdout
+  --output <path>             Write to file instead of stdout
   --verbose, -v               Print pipeline stages to stderr
 ```
 
-Examples:
+`compose` does not accept `--request`/`--response`/`--op` — those belong to `resolve` and `validate`.
 
 ```bash
-# Compose and inspect the merged schema
+# Inspect the merged schema before resolution
 ucp-schema compose response.json --schema-local-base ./schemas --pretty
 
-# Save composed schema for debugging
+# Save for debugging
 ucp-schema compose response.json --schema-local-base ./schemas --output composed.json
-
-# See pipeline stages
-ucp-schema compose response.json --schema-local-base ./schemas --verbose
 ```
 
-Note: `compose` does NOT accept `--request`/`--response`/`--op` flags — those belong to `resolve` and `validate`. If you need a resolved schema, use `resolve` with a payload input.
+### `resolve` — Generate operation-specific schema
 
-### `lint` - Static analysis of schema files
+Accepts a schema file or a self-describing payload. When given a payload, automatically composes schemas from capabilities before resolving.
 
-Catch schema errors before runtime. The linter checks for issues that would cause failures during resolution or validation.
+```bash
+# Schema input (direction required)
+ucp-schema resolve <schema> --request|--response --op <operation> [options]
+
+# Payload input (direction auto-inferred)
+ucp-schema resolve <payload> --op <operation> --schema-local-base <dir> [options]
+
+Options:
+  --request / --response      Direction (required for schema input, auto-inferred for payloads)
+  --op <operation>            Operation: create, read, update, complete
+  --pretty                    Pretty-print JSON output
+  --output <path>             Write to file instead of stdout
+  --bundle                    Inline external $ref pointers (schema input only; payloads bundle automatically)
+  --schema-local-base <dir>   Local directory for schema resolution (payload input only)
+  --schema-remote-base <url>  URL prefix to strip when mapping to local
+  --strict                    Inject additionalProperties: false (see Concepts > Strict Mode)
+  --verbose, -v               Print pipeline stages to stderr
+```
+
+```bash
+# Schema file → resolved schema
+ucp-schema resolve checkout.json --request --op create --pretty
+
+# Self-describing payload → auto-compose, auto-detect direction, resolve
+ucp-schema resolve response.json --op read --schema-local-base ./schemas
+
+# Bundle external $refs into a self-contained schema
+ucp-schema resolve checkout.json --request --op create --bundle --pretty
+
+# Resolve from URL
+ucp-schema resolve https://ucp.dev/schemas/checkout.json --request --op create
+```
+
+### `validate` — Validate payload against resolved schema
+
+```bash
+ucp-schema validate <payload> --op <operation> [options]
+
+Options:
+  --schema <path|url>          Explicit schema (skips self-describing detection)
+  --profile <path|url>         Agent profile (REST request pattern)
+  --request / --response       Direction (required with --schema, auto-detected otherwise)
+  --op <operation>             Operation: create, read, update, complete
+  --schema-local-base <dir>    Local directory to resolve schema URLs
+  --schema-remote-base <url>   URL prefix to strip when mapping to local
+  --strict                     Reject unknown fields (see Concepts > Strict Mode)
+  --json                       Machine-readable JSON output
+  --verbose, -v                Print pipeline stages to stderr
+```
+
+The validator auto-detects how to find the schema based on what flags you provide and what metadata the payload contains (see [Validation Modes](#validation-modes) in Concepts):
+
+| Pattern | Command | Schema Source | Direction |
+|---------|---------|--------------|-----------|
+| **Response** (self-describing) | `validate response.json --op read` | `ucp.capabilities` URLs | Auto |
+| **JSONRPC request** | `validate envelope.json --op create` | `meta.profile` URL | Auto |
+| **REST request** | `validate payload.json --profile profile.json --op create` | `--profile` URL | Request |
+| **Explicit schema** | `validate payload.json --schema s.json --request --op create` | `--schema` | Specified |
+
+```bash
+# Self-describing response
+ucp-schema validate response.json --op read --schema-local-base ./schemas
+
+# Explicit schema
+ucp-schema validate order.json --schema checkout.json --request --op create
+
+# Machine-readable output for CI
+ucp-schema validate order.json --schema checkout.json --request --op create --json
+# → {"valid":true}
+# → {"valid":false,"errors":[{"path":"","message":"..."}]}
+```
+
+Exit codes: `0` valid, `1` validation failed, `2` schema error, `3` file/network error.
+
+### `lint` — Static analysis of schema files
+
+Catch schema errors before runtime.
 
 ```bash
 ucp-schema lint <path> [options]
@@ -317,41 +161,28 @@ Options:
   --quiet, -q           Only show errors, suppress progress
 ```
 
-**What it checks:**
-
-| Category    | Issue                                                        | Severity |
-| ----------- | ------------------------------------------------------------ | -------- |
-| Syntax      | Invalid JSON                                                 | Error    |
-| References  | `$ref` to missing file                                       | Error    |
-| References  | `$ref` to missing anchor (e.g., `#/$defs/foo`)               | Error    |
-| Annotations | Invalid `ucp_*` type (must be string or object)              | Error    |
-| Annotations | Invalid visibility value (must be omit/required/optional)    | Error    |
-| Hygiene     | Missing `$id` field                                          | Warning  |
-| Hygiene     | Unknown operation in annotation (e.g., `{"delete": "omit"}`) | Warning  |
-
-**Examples:**
+| Category | Issue | Severity |
+|----------|-------|----------|
+| Syntax | Invalid JSON | Error |
+| References | `$ref` to missing file | Error |
+| References | `$ref` to missing anchor (`#/$defs/foo`) | Error |
+| Annotations | Invalid `ucp_*` type (must be string or object) | Error |
+| Annotations | Invalid visibility value (must be omit/required/optional) | Error |
+| Hygiene | Missing `$id` field | Warning |
+| Hygiene | Unknown operation in annotation (e.g., `{"delete": "omit"}`) | Warning |
 
 ```bash
 # Lint a directory of schemas
 ucp-schema lint schemas/
 
-# Lint single file, fail on warnings
-ucp-schema lint checkout.json --strict
-
-# CI-friendly JSON output
-ucp-schema lint schemas/ --format json
-
-# Quiet mode - only show errors
-ucp-schema lint schemas/ --quiet
+# CI-friendly: fail on warnings, JSON output
+ucp-schema lint schemas/ --strict --format json
 ```
 
-**Exit codes:**
+Exit codes: `0` passed, `1` errors found, `2` path not found.
 
-- `0` - All files passed (or only warnings in non-strict mode)
-- `1` - Errors found (or warnings in strict mode)
-- `2` - Path not found
-
-**JSON output format:**
+<details>
+<summary>JSON output format</summary>
 
 ```json
 {
@@ -378,9 +209,83 @@ ucp-schema lint schemas/ --quiet
 }
 ```
 
-## Schema Composition from Capabilities
+</details>
 
-UCP responses are self-describing - they embed `ucp.capabilities` declaring which schemas apply:
+## Concepts
+
+### Visibility Rules
+
+`ucp_request` and `ucp_response` annotations control which fields appear in the resolved schema. Given a schema where `id` is server-generated:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "ucp_request": { "create": "omit", "update": "required" }
+    },
+    "name": { "type": "string" }
+  }
+}
+```
+
+Resolving for `--request --op create` removes `id` — clients don't send server-generated fields:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" }
+  }
+}
+```
+
+Resolving for `--request --op update` makes `id` required — you must specify which resource to update:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "name": { "type": "string" }
+  },
+  "required": ["id"]
+}
+```
+
+Annotations are stripped; output is standard JSON Schema.
+
+**Resolution rules:**
+
+| Value | Effect on Properties | Effect on Required Array |
+|-------|---------------------|--------------------------|
+| `"omit"` | Field removed | Field removed |
+| `"required"` | Field kept | Field added |
+| `"optional"` | Field kept | Field removed |
+| (no annotation) | Field kept | Unchanged |
+
+Annotations can be **shorthand** (all operations) or **per-operation**, and request/response are independent:
+
+```json
+{
+  "id": {
+    "type": "string",
+    "ucp_request": { "create": "omit", "update": "required" },
+    "ucp_response": "required"
+  },
+  "status": {
+    "type": "string",
+    "ucp_request": "omit"
+  }
+}
+```
+
+Valid operations: `create`, `read`, `update`, `complete`.
+
+### Schema Composition
+
+UCP payloads are self-describing — they embed `ucp.capabilities` metadata declaring which schemas apply. This lets multiple capability schemas compose into one:
 
 ```json
 {
@@ -397,33 +302,22 @@ UCP responses are self-describing - they embed `ucp.capabilities` declaring whic
       }]
     }
   },
-  "id": "...",
-  "discounts": { ... }
+  "id": "chk_123",
+  "discounts": [...]
 }
 ```
 
 **How composition works:**
 
-1. **Root capability**: One capability has no `extends` - this is the base schema
-2. **Extensions**: Capabilities with `extends` add fields to the root
-3. **Composition**: Extensions define their additions in `$defs[root_capability_name]`
-4. **allOf merge**: The composed schema uses `allOf` to combine all extensions
+1. **Root capability** — one capability has no `extends`, providing the base schema
+2. **Extensions** — capabilities with `extends` add fields to the root
+3. **Merge** — extensions define their additions in `$defs[root_capability_name]`; the tool composes them via `allOf`
 
-For the example above, the composed schema is:
-
-```json
-{
-  "allOf": [
-    {
-      /* checkout's $defs["dev.ucp.shopping.checkout"] from discount.json */
-    }
-  ]
-}
-```
+**Graph rules:** exactly one root capability (no `extends`), all `extends` targets must exist in capabilities, all extensions must transitively reach the root.
 
 **Schema authoring for extensions:**
 
-Extension schemas must define their additions in `$defs` under the root capability name:
+Extension schemas define their additions in `$defs` keyed by the root capability name:
 
 ```json
 {
@@ -436,9 +330,7 @@ Extension schemas must define their additions in `$defs` under the root capabili
         {
           "type": "object",
           "properties": {
-            "discounts": {
-              /* discount-specific fields */
-            }
+            "discounts": { "type": "array" }
           }
         }
       ]
@@ -447,157 +339,115 @@ Extension schemas must define their additions in `$defs` under the root capabili
 }
 ```
 
-**Graph validation:**
+### Validation Modes
 
-- Exactly one root capability (no `extends`)
-- All `extends` references must exist in capabilities
-- All extensions must transitively reach the root (no orphan extensions)
+The validator supports four patterns for discovering which schema to validate against.
 
-## Bundling External References
+**Response (self-describing)** — The payload's `ucp.capabilities` declares schema URLs. Direction is auto-detected as response:
 
-UCP schemas often use `$ref` to reference external files:
+```bash
+ucp-schema validate response.json --op read --schema-local-base ./schemas
+```
+
+**JSONRPC request** — The envelope has `meta.profile` at root, with the payload nested under the capability short name (e.g., `checkout`). The validator fetches the profile, extracts capabilities, extracts the nested payload, then composes and validates:
 
 ```json
 {
-  "properties": {
-    "buyer": { "$ref": "types/buyer.json" },
-    "shipping": { "$ref": "types/address.json#/$defs/postal" }
-  }
+  "meta": { "profile": "https://agent.example.com/.well-known/ucp" },
+  "checkout": { "line_items": [...] }
 }
 ```
 
-The `--bundle` flag inlines all external references, producing a self-contained schema:
+```bash
+ucp-schema validate envelope.json --op create
+```
+
+**REST request (`--profile`)** — The profile URL comes via flag (equivalent to an HTTP header in production). The payload is the raw object, not wrapped in an envelope:
+
+```bash
+ucp-schema validate raw-checkout.json --profile agent-profile.json --op create
+```
+
+The `--profile` flag implies `--request` direction.
+
+**Explicit schema** — Bypass self-describing metadata entirely. Requires explicit `--request` or `--response`:
+
+```bash
+ucp-schema validate order.json --schema checkout.json --request --op create
+```
+
+#### Local Resolution
+
+When working offline or testing schema changes, `--schema-local-base` maps schema URL paths to local files:
+
+```bash
+# Schema URL: https://ucp.dev/schemas/shopping/checkout.json
+# Path extracted: /schemas/shopping/checkout.json
+# Local file: ./local/schemas/shopping/checkout.json
+ucp-schema validate response.json --schema-local-base ./local --op read
+```
+
+When schema URLs have a prefix that doesn't match your local directory layout, `--schema-remote-base` strips it:
+
+```bash
+# URL:   https://ucp.dev/draft/schemas/shopping/checkout.json
+# Strip: https://ucp.dev/draft
+# Local: ./site/schemas/shopping/checkout.json
+ucp-schema validate response.json \
+  --schema-local-base ./site \
+  --schema-remote-base "https://ucp.dev/draft" \
+  --op read
+```
+
+### Bundling
+
+Schemas often use `$ref` to reference external files. The `--bundle` flag inlines all external references into a self-contained schema:
 
 ```bash
 ucp-schema resolve checkout.json --request --op create --bundle --pretty
 ```
 
-**When to use bundling:**
+Bundling applies to **schema file input only**. When resolving payloads, composition already handles fetching and merging external schemas.
 
-- Distributing schemas without file dependencies
-- Feeding schemas to tools that don't support external refs
-- Debugging to see the fully-expanded schema
-- Pre-processing for faster repeated validation
+How it works:
 
-**How it works:**
+- File refs (`"$ref": "types/buyer.json"`) are loaded and inlined
+- Fragment refs (`"$ref": "types/common.json#/$defs/address"`) navigate to the target definition
+- Internal refs in external files (`"$ref": "#/$defs/foo"`) resolve against their source file
+- Self-referential types (`"$ref": "#"`) are preserved (can't be inlined)
+- Circular references are detected and reported as errors
 
-- External file refs (`"$ref": "types/buyer.json"`) are loaded and inlined
-- Fragment refs (`"$ref": "types/common.json#/$defs/address"`) navigate to the specific definition
-- Internal refs within external files (`"$ref": "#/$defs/foo"`) resolve correctly against their source file
-- Self-referential recursive types (`"$ref": "#"`) are preserved (can't be inlined)
-- Circular references between files are detected and reported as errors
+### Strict Mode
 
-## Validation
-
-By default, the validator respects UCP's extensibility model:
-
-- **Validates:** Payload conforms to spec shape (types, required fields, enums, nested structures)
-- **Allows:** Additional/unknown fields (extensibility is intentional)
+By default, validation allows unknown fields — payloads may contain fields from capabilities the validator hasn't seen, and forward compatibility requires tolerating them. For closed systems or catching typos, `--strict` injects `additionalProperties: false` into all object schemas:
 
 ```bash
-# Validates that known fields are correct, allows extra fields
-ucp-schema validate response.json --op read
+ucp-schema validate order.json --schema schema.json --request --op create --strict
+ucp-schema resolve schema.json --request --op create --strict --pretty
 ```
 
-This works because UCP schemas use `additionalProperties: true` intentionally - extensions add new fields, and forward compatibility requires tolerating unknown fields.
-
-**Enabling strict mode:**
-
-For cases where you want to reject unknown fields (e.g., closed systems, catching typos):
-
-```bash
-# Reject any fields not defined in schema
-ucp-schema validate payload.json --schema schema.json --request --op create --strict=true
-
-# Resolved schema will have additionalProperties: false injected
-ucp-schema resolve schema.json --request --op create --strict=true
-```
-
-**What strict mode does:**
-
-- Adds `additionalProperties: false` to all object schemas (root, nested, in arrays, in definitions)
-- Only injects `false` when `additionalProperties` is missing or explicitly `true`
-- Preserves custom `additionalProperties` schemas (e.g., `{"type": "string"}`)
-- Preserves explicit `additionalProperties: false`
-
-**Note:** Strict mode does not work well with `allOf` composition (each branch validates independently and rejects properties from other branches). Use default non-strict mode for composed schemas.
-
-## Visibility Rules
-
-Annotations control how fields appear in the resolved schema:
-
-| Value           | Effect on Properties | Effect on Required Array |
-| --------------- | -------------------- | ------------------------ |
-| `"omit"`        | Field removed        | Field removed            |
-| `"required"`    | Field kept           | Field added              |
-| `"optional"`    | Field kept           | Field removed            |
-| (no annotation) | Field kept           | Unchanged                |
-
-### Annotation Formats
-
-**Shorthand** - applies to all operations:
-
-```json
-{ "ucp_request": "omit" }
-```
-
-**Per-operation** - different behavior per operation:
-
-```json
-{ "ucp_request": { "create": "omit", "update": "required", "read": "omit" } }
-```
-
-**Separate request/response:**
-
-```json
-{
-  "ucp_request": { "create": "omit" },
-  "ucp_response": "required"
-}
-```
-
-## How It Works
-
-Each CLI command corresponds to a depth in the processing pipeline:
-
-```
-compose   ■ □ □     compose only (annotations preserved)
-resolve   ■ ■ □     compose + resolve (if payload input)
-validate  ■ ■ ■     compose + resolve + validate
-lint      independent static analysis
-```
-
-When `resolve` or `validate` receives a self-describing payload (detected by `ucp.capabilities` or `meta.profile`), the compose step runs automatically. When given a plain schema file, only the later stages run.
-
-**"I want to..."**
-
-| Goal | Command |
-|------|---------|
-| See the composed schema with annotations | `compose response.json --schema-local-base ./schemas --pretty` |
-| Get a standard JSON Schema for an operation | `resolve response.json --op read --schema-local-base ./schemas` |
-| Validate a payload end-to-end | `validate response.json --op read --schema-local-base ./schemas` |
-| Resolve a single schema file | `resolve schema.json --request --op create` |
-| Debug what the pipeline is doing | Add `--verbose` to any command |
+**Warning:** Strict mode conflicts with `allOf` composition. Each `allOf` branch validates independently and rejects properties from other branches. Use default (non-strict) mode for composed schemas.
 
 ## Debugging with `--verbose`
 
-All commands accept `--verbose` (or `-v`) which prints pipeline stages to stderr:
+All commands accept `--verbose` (or `-v`) to print pipeline stages to stderr:
 
 ```bash
 $ ucp-schema resolve response.json --op read --schema-local-base ./schemas --verbose
 [load] reading response.json
-[detect] payload with 2 capabilities (1 root, 1 extensions)
+[detect] payload with 3 capabilities (1 root, 2 extensions)
 [detect]   root dev.ucp.shopping.checkout → https://ucp.dev/schemas/shopping/checkout.json
-[detect]   ext  dev.ucp.shopping.discount → https://ucp.dev/schemas/shopping/discount.json
+[detect]   ext dev.ucp.shopping.discount → https://ucp.dev/schemas/shopping/discount.json
+[detect]   ext dev.ucp.shopping.fulfillment → https://ucp.dev/schemas/shopping/fulfillment.json
 [compose] composing schemas from payload capabilities
 [resolve] resolving for response/read
 ```
 
-Verbose output goes to stderr, so it doesn't interfere with JSON output on stdout.
+Verbose output goes to stderr; JSON output on stdout is unaffected.
 
 ## More Information
 
-See **[FAQ.md](./FAQ.md)** for common questions about validator behavior and design decisions
+See [FAQ.md](./FAQ.md) for common questions about validator behavior, design decisions, and edge cases.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ For example, a field annotated with `"ucp_request": {"create": "omit", "update":
 
 **"I want to..."**
 
-| Goal | Command |
-|------|---------|
-| Inspect the composed schema (annotations preserved) | `compose payload.json --schema-local-base ./schemas --pretty` |
-| Get JSON Schema for an operation | `resolve payload.json --op read --schema-local-base ./schemas` |
-| Resolve a single schema file (no composition) | `resolve schema.json --request --op create` |
-| Validate a payload end-to-end | `validate payload.json --op read --schema-local-base ./schemas` |
-| Check schemas for errors before runtime | `lint schemas/` |
-| Debug what the pipeline is doing | Add `--verbose` to any command |
+| Goal                                                | Command                                                         |
+| --------------------------------------------------- | --------------------------------------------------------------- |
+| Inspect the composed schema (annotations preserved) | `compose payload.json --schema-local-base ./schemas --pretty`   |
+| Get JSON Schema for an operation                    | `resolve payload.json --op read --schema-local-base ./schemas`  |
+| Resolve a single schema file (no composition)       | `resolve schema.json --request --op create`                     |
+| Validate a payload end-to-end                       | `validate payload.json --op read --schema-local-base ./schemas` |
+| Check schemas for errors before runtime             | `lint schemas/`                                                 |
+| Debug what the pipeline is doing                    | Add `--verbose` to any command                                  |
 
 ## Installation
 
@@ -126,12 +126,12 @@ Options:
 
 The validator auto-detects how to find the schema based on what flags you provide and what metadata the payload contains (see [Validation Modes](#validation-modes) in Concepts):
 
-| Pattern | Command | Schema Source | Direction |
-|---------|---------|--------------|-----------|
-| **Response** (self-describing) | `validate response.json --op read` | `ucp.capabilities` URLs | Auto |
-| **JSONRPC request** | `validate envelope.json --op create` | `meta.profile` URL | Auto |
-| **REST request** | `validate payload.json --profile profile.json --op create` | `--profile` URL | Request |
-| **Explicit schema** | `validate payload.json --schema s.json --request --op create` | `--schema` | Specified |
+| Pattern                        | Command                                                       | Schema Source           | Direction |
+| ------------------------------ | ------------------------------------------------------------- | ----------------------- | --------- |
+| **Response** (self-describing) | `validate response.json --op read`                            | `ucp.capabilities` URLs | Auto      |
+| **JSONRPC request**            | `validate envelope.json --op create`                          | `meta.profile` URL      | Auto      |
+| **REST request**               | `validate payload.json --profile profile.json --op create`    | `--profile` URL         | Request   |
+| **Explicit schema**            | `validate payload.json --schema s.json --request --op create` | `--schema`              | Specified |
 
 ```bash
 # Self-describing response
@@ -161,15 +161,15 @@ Options:
   --quiet, -q           Only show errors, suppress progress
 ```
 
-| Category | Issue | Severity |
-|----------|-------|----------|
-| Syntax | Invalid JSON | Error |
-| References | `$ref` to missing file | Error |
-| References | `$ref` to missing anchor (`#/$defs/foo`) | Error |
-| Annotations | Invalid `ucp_*` type (must be string or object) | Error |
-| Annotations | Invalid visibility value (must be omit/required/optional) | Error |
-| Hygiene | Missing `$id` field | Warning |
-| Hygiene | Unknown operation in annotation (e.g., `{"delete": "omit"}`) | Warning |
+| Category    | Issue                                                        | Severity |
+| ----------- | ------------------------------------------------------------ | -------- |
+| Syntax      | Invalid JSON                                                 | Error    |
+| References  | `$ref` to missing file                                       | Error    |
+| References  | `$ref` to missing anchor (`#/$defs/foo`)                     | Error    |
+| Annotations | Invalid `ucp_*` type (must be string or object)              | Error    |
+| Annotations | Invalid visibility value (must be omit/required/optional)    | Error    |
+| Hygiene     | Missing `$id` field                                          | Warning  |
+| Hygiene     | Unknown operation in annotation (e.g., `{"delete": "omit"}`) | Warning  |
 
 ```bash
 # Lint a directory of schemas
@@ -258,12 +258,12 @@ Annotations are stripped; output is standard JSON Schema.
 
 **Resolution rules:**
 
-| Value | Effect on Properties | Effect on Required Array |
-|-------|---------------------|--------------------------|
-| `"omit"` | Field removed | Field removed |
-| `"required"` | Field kept | Field added |
-| `"optional"` | Field kept | Field removed |
-| (no annotation) | Field kept | Unchanged |
+| Value           | Effect on Properties | Effect on Required Array |
+| --------------- | -------------------- | ------------------------ |
+| `"omit"`        | Field removed        | Field removed            |
+| `"required"`    | Field kept           | Field added              |
+| `"optional"`    | Field kept           | Field removed            |
+| (no annotation) | Field kept           | Unchanged                |
 
 Annotations can be **shorthand** (all operations) or **per-operation**, and request/response are independent:
 

--- a/src/bin/ucp-schema.rs
+++ b/src/bin/ucp-schema.rs
@@ -8,9 +8,10 @@ use std::process::ExitCode;
 use clap::{Parser, Subcommand};
 use ucp_schema::{
     bundle_refs, bundle_refs_with_url_mapping, compose_from_payload, compose_schema,
-    detect_direction, extract_capabilities_from_profile, extract_jsonrpc_payload, is_url, lint,
-    load_schema, load_schema_auto, resolve, validate, ComposeError, DetectedDirection, Direction,
-    FileStatus, ResolveError, ResolveOptions, SchemaBaseConfig, ValidateError,
+    detect_direction, extract_capabilities, extract_capabilities_from_profile,
+    extract_jsonrpc_payload, is_url, lint, load_schema, load_schema_auto, resolve, validate,
+    ComposeError, DetectedDirection, Direction, FileStatus, ResolveError, ResolveOptions,
+    SchemaBaseConfig, ValidateError,
 };
 
 /// Errors with associated CLI exit codes.
@@ -52,18 +53,18 @@ fn cli_err_ctx<'a, E: std::fmt::Display + CliExitCode>(
 /// Determine direction from CLI flags and optional inference.
 ///
 /// Priority: explicit --request/--response flags override inference.
-/// When neither flag is set, uses inferred direction or defaults to Request.
+/// When neither flag is set, uses inferred direction if available.
 fn determine_direction(
     request_flag: bool,
     response_flag: bool,
     inferred: Option<Direction>,
-) -> Direction {
+) -> Option<Direction> {
     if request_flag {
-        Direction::Request
+        Some(Direction::Request)
     } else if response_flag {
-        Direction::Response
+        Some(Direction::Response)
     } else {
-        inferred.unwrap_or(Direction::Request)
+        inferred
     }
 }
 
@@ -81,21 +82,18 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Resolve a schema for a specific direction and operation
+    /// Resolve a schema for a specific direction and operation.
+    /// Accepts a schema file or a self-describing payload (auto-composes if payload detected).
     Resolve {
-        /// Schema source: file path or URL (http:// or https://)
+        /// Schema or payload source: file path or URL (http:// or https://)
         schema: String,
 
-        /// Resolve for request direction
-        #[arg(
-            long,
-            conflicts_with = "response",
-            required_unless_present = "response"
-        )]
+        /// Resolve for request direction (auto-inferred for payloads)
+        #[arg(long, conflicts_with = "response")]
         request: bool,
 
-        /// Resolve for response direction
-        #[arg(long, conflicts_with = "request", required_unless_present = "request")]
+        /// Resolve for response direction (auto-inferred for payloads)
+        #[arg(long, conflicts_with = "request")]
         response: bool,
 
         /// Operation to resolve for (e.g., create, update, read)
@@ -110,13 +108,25 @@ enum Commands {
         #[arg(long)]
         pretty: bool,
 
-        /// Dereference all $ref pointers (bundle into single schema)
+        /// Dereference all $ref pointers (bundle into single schema; schema input only)
         #[arg(long)]
         bundle: bool,
+
+        /// Local directory containing schema files (used when input is a payload)
+        #[arg(long)]
+        schema_local_base: Option<PathBuf>,
+
+        /// URL prefix to strip when mapping to local (e.g., https://ucp.dev/draft)
+        #[arg(long, requires = "schema_local_base")]
+        schema_remote_base: Option<String>,
 
         /// Strict mode: set additionalProperties=false to reject unknown fields (default: false)
         #[arg(long, default_value_t = false, action = clap::ArgAction::Set)]
         strict: bool,
+
+        /// Print pipeline stages to stderr for debugging
+        #[arg(long, short)]
+        verbose: bool,
     },
 
     /// Validate a payload against a resolved schema
@@ -159,6 +169,36 @@ enum Commands {
         /// Strict mode: reject unknown fields (default: false)
         #[arg(long, default_value_t = false, action = clap::ArgAction::Set)]
         strict: bool,
+
+        /// Print pipeline stages to stderr for debugging
+        #[arg(long, short)]
+        verbose: bool,
+    },
+
+    /// Compose capability schemas from a self-describing payload (annotations preserved)
+    Compose {
+        /// Payload file with UCP capabilities metadata
+        payload: PathBuf,
+
+        /// Local directory containing schema files
+        #[arg(long)]
+        schema_local_base: Option<PathBuf>,
+
+        /// URL prefix to strip when mapping to local (e.g., https://ucp.dev/draft)
+        #[arg(long, requires = "schema_local_base")]
+        schema_remote_base: Option<String>,
+
+        /// Output file (stdout if not specified)
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Pretty-print JSON output
+        #[arg(long)]
+        pretty: bool,
+
+        /// Print pipeline stages to stderr for debugging
+        #[arg(long, short)]
+        verbose: bool,
     },
 
     /// Lint schema files for errors (syntax, broken refs, invalid annotations)
@@ -187,13 +227,44 @@ fn main() -> ExitCode {
         Commands::Resolve {
             schema,
             request,
-            response: _,
+            response,
             op,
             output,
             pretty,
             bundle,
+            schema_local_base,
+            schema_remote_base,
             strict,
-        } => run_resolve(&schema, request, op, output, pretty, bundle, strict),
+            verbose,
+        } => run_resolve(
+            &schema,
+            request,
+            response,
+            op,
+            output,
+            pretty,
+            bundle,
+            schema_local_base,
+            schema_remote_base,
+            strict,
+            verbose,
+        ),
+
+        Commands::Compose {
+            payload,
+            schema_local_base,
+            schema_remote_base,
+            output,
+            pretty,
+            verbose,
+        } => run_compose(
+            &payload,
+            schema_local_base,
+            schema_remote_base,
+            output,
+            pretty,
+            verbose,
+        ),
 
         Commands::Validate {
             payload,
@@ -206,6 +277,7 @@ fn main() -> ExitCode {
             op,
             json,
             strict,
+            verbose,
         } => run_validate(ValidateArgs {
             payload,
             schema,
@@ -217,6 +289,7 @@ fn main() -> ExitCode {
             op,
             json_output: json,
             strict,
+            verbose,
         }),
 
         Commands::Lint {
@@ -233,56 +306,129 @@ fn main() -> ExitCode {
     }
 }
 
+/// Resolve a schema for a specific direction and operation.
+///
+/// Auto-detects input type: if the input is a self-describing payload (has
+/// ucp.capabilities or meta.profile), composes schemas first then resolves.
+/// Otherwise resolves the schema directly.
+#[allow(clippy::too_many_arguments)]
 fn run_resolve(
     schema_source: &str,
     request: bool,
+    response: bool,
     op: String,
     output: Option<PathBuf>,
     pretty: bool,
     bundle: bool,
+    schema_local_base: Option<PathBuf>,
+    schema_remote_base: Option<String>,
     strict: bool,
+    verbose: bool,
 ) -> Result<(), u8> {
-    // run_resolve has no --json flag, so errors always go to stderr (json_output=false)
-    let direction = Direction::from_request_flag(request);
+    if verbose {
+        eprintln!("[load] reading {}", schema_source);
+    }
+    let mut input = load_schema_auto(schema_source).map_err(cli_err(false))?;
 
-    let mut schema = load_schema_auto(schema_source).map_err(cli_err(false))?;
+    // Auto-detect: is this a payload (needs compose) or a schema (resolve directly)?
+    let detected = detect_direction(&input);
 
-    // Bundle: dereference all $refs before resolving annotations
-    if bundle {
-        // Resolve external file refs and their internal refs using our loader
-        // Note: $ref: "#" (self-refs) are left as-is since they're recursive
-        let base_dir = std::path::Path::new(schema_source)
-            .parent()
-            .unwrap_or(std::path::Path::new("."));
-        bundle_refs(&mut schema, base_dir).map_err(cli_err_ctx(false, "bundling refs"))?;
+    // Flag validation: reject flags that don't apply to the detected input type
+    if detected.is_some() {
+        if bundle {
+            report_error(false, "--bundle does not apply to payload input (schemas are auto-composed from capabilities). Remove --bundle, or pass a schema file instead of a payload.");
+            return Err(2);
+        }
+    } else if schema_local_base.is_some() || schema_remote_base.is_some() {
+        report_error(false, "--schema-local-base/--schema-remote-base only apply to payload input. Remove these flags, or pass a self-describing payload instead of a schema file.");
+        return Err(2);
     }
 
-    let options = ResolveOptions::new(direction, op).strict(strict);
+    let schema = if detected.is_some() {
+        // Input is a self-describing payload — compose schemas from capabilities
+        let config = SchemaBaseConfig {
+            local_base: schema_local_base.as_deref(),
+            remote_base: schema_remote_base.as_deref(),
+        };
+        if verbose {
+            verbose_capabilities(&input, &config);
+            eprintln!("[compose] composing schemas from payload capabilities");
+        }
+        compose_from_payload(&input, &config).map_err(cli_err(false))?
+    } else {
+        if verbose {
+            eprintln!("[detect] input is a schema file (no ucp.capabilities)");
+        }
+        // Input is a schema file — bundle $refs if requested
+        if bundle {
+            if verbose {
+                eprintln!("[bundle] inlining $ref pointers");
+            }
+            let base_dir = Path::new(schema_source).parent().unwrap_or(Path::new("."));
+            bundle_refs(&mut input, base_dir).map_err(cli_err_ctx(false, "bundling refs"))?;
+        }
+        input
+    };
+
+    // Direction: explicit flag > auto-inferred from payload > require explicit
+    let direction = determine_direction(request, response, detected.map(Direction::from))
+        .ok_or_else(|| {
+            report_error(
+                false,
+                "--request or --response is required for schema input",
+            );
+            2u8
+        })?;
+
+    let options = ResolveOptions::new(direction, &op).strict(strict);
+    if verbose {
+        eprintln!(
+            "[resolve] resolving for {}/{}{}",
+            direction
+                .annotation_key()
+                .strip_prefix("ucp_")
+                .unwrap_or(direction.annotation_key()),
+            op,
+            if strict { " (strict)" } else { "" }
+        );
+    }
     let resolved = resolve(&schema, &options).map_err(cli_err(false))?;
 
-    let json_output = if pretty {
-        serde_json::to_string_pretty(&resolved)
-    } else {
-        serde_json::to_string(&resolved)
-    }
-    .map_err(|e| {
-        eprintln!("Error serializing output: {}", e);
-        2u8
-    })?;
+    write_json_output(&resolved, output, pretty)
+}
 
-    match output {
-        Some(path) => {
-            std::fs::write(&path, &json_output).map_err(|e| {
-                eprintln!("Error writing to {}: {}", path.display(), e);
-                3u8
-            })?;
-        }
-        None => {
-            println!("{}", json_output);
-        }
+/// Pure composition: merge capability schemas from a self-describing payload.
+/// Output preserves UCP annotations (no resolve step).
+fn run_compose(
+    payload_path: &Path,
+    schema_local_base: Option<PathBuf>,
+    schema_remote_base: Option<String>,
+    output: Option<PathBuf>,
+    pretty: bool,
+    verbose: bool,
+) -> Result<(), u8> {
+    if verbose {
+        eprintln!("[load] reading {}", payload_path.display());
+    }
+    let payload = load_schema(payload_path).map_err(cli_err_ctx(false, "loading payload"))?;
+
+    // Verify input is a self-describing payload
+    if detect_direction(&payload).is_none() {
+        report_error(false, "input is not a self-describing payload (missing ucp.capabilities or meta.profile). Use `resolve` for schema files.");
+        return Err(2);
     }
 
-    Ok(())
+    let config = SchemaBaseConfig {
+        local_base: schema_local_base.as_deref(),
+        remote_base: schema_remote_base.as_deref(),
+    };
+    if verbose {
+        verbose_capabilities(&payload, &config);
+        eprintln!("[compose] composing schemas (annotations preserved)");
+    }
+    let schema = compose_from_payload(&payload, &config).map_err(cli_err(false))?;
+
+    write_json_output(&schema, output, pretty)
 }
 
 struct ValidateArgs {
@@ -296,6 +442,7 @@ struct ValidateArgs {
     op: String,
     json_output: bool,
     strict: bool,
+    verbose: bool,
 }
 
 fn run_validate(args: ValidateArgs) -> Result<(), u8> {
@@ -310,7 +457,15 @@ fn run_validate(args: ValidateArgs) -> Result<(), u8> {
         op,
         json_output,
         strict,
+        verbose,
     } = args;
+
+    // Flag validation: --schema-local-base/--schema-remote-base don't apply with
+    // explicit --schema (composition is bypassed, so these would silently do nothing)
+    if schema_source.is_some() && (schema_local_base.is_some() || schema_remote_base.is_some()) {
+        report_error(json_output, "--schema-local-base/--schema-remote-base do not apply with explicit --schema (composition is bypassed). Remove these flags, or remove --schema to use self-describing mode.");
+        return Err(2);
+    }
 
     let config = SchemaBaseConfig {
         local_base: schema_local_base.as_deref(),
@@ -318,6 +473,9 @@ fn run_validate(args: ValidateArgs) -> Result<(), u8> {
     };
 
     // Load payload file
+    if verbose {
+        eprintln!("[load] reading payload {}", payload_path.display());
+    }
     let payload_file =
         load_schema(&payload_path).map_err(cli_err_ctx(json_output, "loading payload"))?;
 
@@ -328,18 +486,31 @@ fn run_validate(args: ValidateArgs) -> Result<(), u8> {
     // 4. Response: ucp.capabilities in payload, payload is self-describing
     let (schema, payload, direction) = if let Some(ref profile) = profile_url {
         // REST pattern: --profile flag provides profile URL, payload is raw
-        let direction = determine_direction(request, response, None);
+        if verbose {
+            eprintln!("[detect] REST pattern: using --profile {}", profile);
+        }
+        let direction = determine_direction(request, response, None).unwrap_or(Direction::Request);
 
         let capabilities =
             extract_capabilities_from_profile(profile, &config).map_err(cli_err(json_output))?;
 
+        if verbose {
+            eprintln!(
+                "[compose] composing {} capability schemas from profile",
+                capabilities.len()
+            );
+        }
         let schema = compose_schema(&capabilities, &config).map_err(cli_err(json_output))?;
 
         (schema, payload_file, direction)
     } else if let Some(ref source) = schema_source {
         // Explicit schema: try to infer direction from payload
+        if verbose {
+            eprintln!("[load] using explicit schema: {}", source);
+        }
         let inferred = detect_direction(&payload_file).map(Direction::from);
-        let direction = determine_direction(request, response, inferred);
+        let direction =
+            determine_direction(request, response, inferred).unwrap_or(Direction::Request);
 
         let mut schema =
             load_schema_auto(source).map_err(cli_err_ctx(json_output, "loading schema"))?;
@@ -377,14 +548,20 @@ fn run_validate(args: ValidateArgs) -> Result<(), u8> {
         match detect_direction(&payload_file) {
             Some(DetectedDirection::Response) => {
                 // Response: ucp.capabilities, compose and validate full payload
-                let direction = determine_direction(request, response, Some(Direction::Response));
+                if verbose {
+                    verbose_capabilities(&payload_file, &config);
+                    eprintln!("[compose] composing schemas from payload capabilities");
+                }
+                let direction = determine_direction(request, response, Some(Direction::Response))
+                    .unwrap_or(Direction::Response);
                 let schema =
                     compose_from_payload(&payload_file, &config).map_err(cli_err(json_output))?;
                 (schema, payload_file, direction)
             }
             Some(DetectedDirection::Request) => {
                 // JSONRPC request: meta.profile, extract nested payload
-                let direction = determine_direction(request, response, Some(Direction::Request));
+                let direction = determine_direction(request, response, Some(Direction::Request))
+                    .unwrap_or(Direction::Request);
 
                 // Get profile URL from meta.profile
                 let profile = payload_file
@@ -396,6 +573,10 @@ fn run_validate(args: ValidateArgs) -> Result<(), u8> {
                         2u8
                     })?;
 
+                if verbose {
+                    eprintln!("[detect] JSONRPC request: fetching profile {}", profile);
+                }
+
                 let capabilities = extract_capabilities_from_profile(profile, &config)
                     .map_err(cli_err(json_output))?;
 
@@ -403,6 +584,12 @@ fn run_validate(args: ValidateArgs) -> Result<(), u8> {
                 let (nested_payload, _key) = extract_jsonrpc_payload(&payload_file, &capabilities)
                     .map_err(cli_err(json_output))?;
 
+                if verbose {
+                    eprintln!(
+                        "[compose] composing {} capability schemas from profile",
+                        capabilities.len()
+                    );
+                }
                 let schema =
                     compose_schema(&capabilities, &config).map_err(cli_err(json_output))?;
 
@@ -419,6 +606,17 @@ fn run_validate(args: ValidateArgs) -> Result<(), u8> {
     };
 
     let options = ResolveOptions::new(direction, op).strict(strict);
+    if verbose {
+        eprintln!(
+            "[resolve] resolving for {}/{}",
+            direction
+                .annotation_key()
+                .strip_prefix("ucp_")
+                .unwrap_or(direction.annotation_key()),
+            options.operation
+        );
+        eprintln!("[validate] validating payload against resolved schema");
+    }
 
     match validate(&schema, &payload, &options) {
         Ok(()) => {
@@ -447,6 +645,56 @@ fn run_validate(args: ValidateArgs) -> Result<(), u8> {
         Err(ValidateError::Resolve(e)) => {
             report_error(json_output, &e.to_string());
             Err(e.exit_code() as u8)
+        }
+    }
+}
+
+/// Shared helper: serialize JSON and write to output or stdout.
+fn write_json_output(
+    value: &serde_json::Value,
+    output: Option<PathBuf>,
+    pretty: bool,
+) -> Result<(), u8> {
+    let json = if pretty {
+        serde_json::to_string_pretty(value)
+    } else {
+        serde_json::to_string(value)
+    }
+    .map_err(|e| {
+        eprintln!("Error serializing output: {}", e);
+        2u8
+    })?;
+
+    match output {
+        Some(path) => {
+            std::fs::write(&path, &json).map_err(|e| {
+                eprintln!("Error writing to {}: {}", path.display(), e);
+                3u8
+            })?;
+        }
+        None => {
+            println!("{}", json);
+        }
+    }
+
+    Ok(())
+}
+
+/// Print capability details to stderr for --verbose mode.
+/// Best-effort: silently skips if extraction fails (errors surface later).
+fn verbose_capabilities(payload: &serde_json::Value, config: &SchemaBaseConfig) {
+    if let Ok(caps) = extract_capabilities(payload, config) {
+        let roots: Vec<_> = caps.iter().filter(|c| c.extends.is_none()).collect();
+        let exts: Vec<_> = caps.iter().filter(|c| c.extends.is_some()).collect();
+        eprintln!(
+            "[detect] payload with {} capabilities ({} root, {} extensions)",
+            caps.len(),
+            roots.len(),
+            exts.len()
+        );
+        for cap in &caps {
+            let kind = if cap.extends.is_some() { "ext" } else { "root" };
+            eprintln!("[detect]   {} {} → {}", kind, cap.name, cap.schema_url);
         }
     }
 }


### PR DESCRIPTION
`ucp-schema` processes UCP-annotated JSON Schemas through a staged pipeline — analogous to a compiler toolchain:

  - **bundle** — inline `$ref` pointers into a self-contained schema (like `gcc -E`, preprocessing `#include`)
  - **compose** — merge N capability schemas into one via `allOf` (like linking object files into a binary)
  - **resolve** — apply UCP annotations for direction + operation, output JSON Schema (apply `#ifdef` conditionals)
  - **validate** — check a payload against the resolved schema (like running the binary)

Each CLI command runs the pipeline to a different depth. `compose` stops early, `resolve` goes one step further, `validate` runs end-to-end. Before this PR, the pipeline existed but was implicit: `validate` did everything internally, `resolve` only worked on single schema files, and there was no way to inspect intermediate stages. 

This PR makes the pipeline explicit and coherent.

## Changes

 - **New `compose` command** — the missing first stage; outputs composed schema with annotations intact
 - **Flag validation** — rejects flags that don't apply to the input type
 - **`resolve` auto-detection** — accepts payloads directly, auto-composes and auto-infers direction
  - **`--verbose`** mode (new) — prints pipeline stages to stderr on all commands
  - **Fix** — `bundle_refs` couldn't resolve `#/$defs/` refs in the root schema
