### PR TITLE
feat: add --include-future flag to resolve

### DIFF
--- a/src/bin/ucp-schema.rs
+++ b/src/bin/ucp-schema.rs
@@ -124,6 +124,12 @@ enum Commands {
         #[arg(long, default_value_t = false, action = clap::ArgAction::Set)]
         strict: bool,
 
+        /// Include future fields: omit-visibility fields with a transition targeting
+        /// non-omit (planned additions). Surfaces them with x-ucp-schema-transition
+        /// metadata but does not add to required.
+        #[arg(long)]
+        include_future: bool,
+
         /// Print pipeline stages to stderr for debugging
         #[arg(long, short)]
         verbose: bool,
@@ -235,6 +241,7 @@ fn main() -> ExitCode {
             schema_local_base,
             schema_remote_base,
             strict,
+            include_future,
             verbose,
         } => run_resolve(
             &schema,
@@ -247,6 +254,7 @@ fn main() -> ExitCode {
             schema_local_base,
             schema_remote_base,
             strict,
+            include_future,
             verbose,
         ),
 
@@ -323,6 +331,7 @@ fn run_resolve(
     schema_local_base: Option<PathBuf>,
     schema_remote_base: Option<String>,
     strict: bool,
+    include_future: bool,
     verbose: bool,
 ) -> Result<(), u8> {
     if verbose {
@@ -380,8 +389,14 @@ fn run_resolve(
             2u8
         })?;
 
-    let options = ResolveOptions::new(direction, &op).strict(strict);
+    let options = ResolveOptions::new(direction, &op)
+        .strict(strict)
+        .include_future(include_future);
     if verbose {
+        let mut flags = Vec::new();
+        if strict { flags.push("strict"); }
+        if include_future { flags.push("include-future"); }
+        let suffix = if flags.is_empty() { String::new() } else { format!(" ({})", flags.join(", ")) };
         eprintln!(
             "[resolve] resolving for {}/{}{}",
             direction
@@ -389,7 +404,7 @@ fn run_resolve(
                 .strip_prefix("ucp_")
                 .unwrap_or(direction.annotation_key()),
             op,
-            if strict { " (strict)" } else { "" }
+            suffix
         );
     }
     let resolved = resolve(&schema, &options).map_err(cli_err(false))?;

--- a/src/bin/ucp-schema.rs
+++ b/src/bin/ucp-schema.rs
@@ -394,9 +394,17 @@ fn run_resolve(
         .include_future(include_future);
     if verbose {
         let mut flags = Vec::new();
-        if strict { flags.push("strict"); }
-        if include_future { flags.push("include-future"); }
-        let suffix = if flags.is_empty() { String::new() } else { format!(" ({})", flags.join(", ")) };
+        if strict {
+            flags.push("strict");
+        }
+        if include_future {
+            flags.push("include-future");
+        }
+        let suffix = if flags.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", flags.join(", "))
+        };
         eprintln!(
             "[resolve] resolving for {}/{}{}",
             direction

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -365,7 +365,21 @@ fn resolve_properties(
 
         match visibility {
             Visibility::Omit => {
-                // Remove from properties and required
+                // Include future fields: currently omit but transitioning to non-omit.
+                // Completes transition lifecycle symmetry — deprecations (to=omit) are
+                // already surfaced; this surfaces planned additions (from=omit).
+                let is_future = options.include_future
+                    && transition
+                        .as_ref()
+                        .map_or(false, |t| t.to != "omit");
+
+                if is_future {
+                    let resolved = resolve_value(prop_value, options, &prop_path)?;
+                    let mut stripped = strip_annotations(&resolved);
+                    apply_transition_metadata(&mut stripped, &transition);
+                    result.insert(prop_name.clone(), stripped);
+                    // NOT added to required — current visibility is omit
+                }
                 required.retain(|r| r != prop_name);
             }
             Visibility::Required => {
@@ -989,6 +1003,161 @@ mod tests {
             result["properties"]["id"]["x-ucp-schema-transition"]["description"],
             "Removing in v2."
         );
+    }
+
+    #[test]
+    fn resolve_include_future_surfaces_omit_to_nonomit_transition() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "existing": { "type": "string", "ucp_request": "required" },
+                "planned": {
+                    "type": "string",
+                    "description": "A future field.",
+                    "ucp_request": {
+                        "transition": {
+                            "from": "omit",
+                            "to": "required",
+                            "description": "Planned for v2."
+                        }
+                    }
+                }
+            }
+        });
+
+        // Without include_future: planned field is absent
+        let options = ResolveOptions::new(Direction::Request, "create");
+        let result = resolve(&schema, &options).unwrap();
+        assert!(result["properties"].get("existing").is_some());
+        assert!(result["properties"].get("planned").is_none());
+
+        // With include_future: planned field is present with transition metadata
+        let options = ResolveOptions::new(Direction::Request, "create").include_future(true);
+        let result = resolve(&schema, &options).unwrap();
+        assert!(result["properties"].get("existing").is_some());
+        assert!(result["properties"].get("planned").is_some());
+
+        // Transition metadata is emitted
+        let transition = &result["properties"]["planned"]["x-ucp-schema-transition"];
+        assert_eq!(transition["from"], "omit");
+        assert_eq!(transition["to"], "required");
+        assert_eq!(transition["description"], "Planned for v2.");
+
+        // NOT in required (current visibility is omit)
+        let required = result.get("required").and_then(|r| r.as_array());
+        if let Some(req) = required {
+            assert!(!req.contains(&json!("planned")));
+        }
+
+        // Not marked deprecated (to != "omit")
+        assert!(result["properties"]["planned"].get("deprecated").is_none());
+    }
+
+    #[test]
+    fn resolve_include_future_does_not_surface_plain_omit() {
+        // A plain omit field (no transition) stays hidden even with include_future.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "hidden": { "type": "string", "ucp_request": "omit" }
+            }
+        });
+
+        let options = ResolveOptions::new(Direction::Request, "create").include_future(true);
+        let result = resolve(&schema, &options).unwrap();
+        assert!(result["properties"].get("hidden").is_none());
+    }
+
+    #[test]
+    fn resolve_include_future_per_operation_transition() {
+        // Transition scoped to a single operation: "search" is future, "lookup" is omit.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "like": {
+                    "type": "array",
+                    "ucp_request": {
+                        "search": {
+                            "transition": {
+                                "from": "omit",
+                                "to": "optional",
+                                "description": "Planned for search."
+                            }
+                        },
+                        "lookup": "omit"
+                    }
+                }
+            }
+        });
+
+        // search with include_future: like appears
+        let options = ResolveOptions::new(Direction::Request, "search").include_future(true);
+        let result = resolve(&schema, &options).unwrap();
+        assert!(result["properties"].get("like").is_some());
+        assert_eq!(
+            result["properties"]["like"]["x-ucp-schema-transition"]["to"],
+            "optional"
+        );
+
+        // lookup with include_future: like stays hidden (plain omit, no transition)
+        let options = ResolveOptions::new(Direction::Request, "lookup").include_future(true);
+        let result = resolve(&schema, &options).unwrap();
+        assert!(result["properties"].get("like").is_none());
+    }
+
+    #[test]
+    fn resolve_include_future_coexists_with_deprecated() {
+        // Three fields: normal, future (from=omit), deprecated (to=omit).
+        // All three should be present with include_future, each with correct metadata.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "stable": { "type": "string", "ucp_request": "required" },
+                "planned": {
+                    "type": "string",
+                    "ucp_request": {
+                        "transition": {
+                            "from": "omit",
+                            "to": "optional",
+                            "description": "Coming soon."
+                        }
+                    }
+                },
+                "legacy": {
+                    "type": "string",
+                    "ucp_request": {
+                        "transition": {
+                            "from": "optional",
+                            "to": "omit",
+                            "description": "Being removed."
+                        }
+                    }
+                }
+            }
+        });
+
+        let options = ResolveOptions::new(Direction::Request, "create").include_future(true);
+        let result = resolve(&schema, &options).unwrap();
+
+        // stable: present, no transition
+        assert!(result["properties"].get("stable").is_some());
+        assert!(result["properties"]["stable"].get("x-ucp-schema-transition").is_none());
+
+        // planned: present via include_future, transition metadata, not deprecated
+        assert!(result["properties"].get("planned").is_some());
+        assert_eq!(result["properties"]["planned"]["x-ucp-schema-transition"]["from"], "omit");
+        assert!(result["properties"]["planned"].get("deprecated").is_none());
+
+        // legacy: present (from=optional), transition metadata, deprecated=true
+        assert!(result["properties"].get("legacy").is_some());
+        assert_eq!(result["properties"]["legacy"]["x-ucp-schema-transition"]["to"], "omit");
+        assert_eq!(result["properties"]["legacy"]["deprecated"], true);
+
+        // required: only stable (planned is omit-visibility, legacy is optional)
+        let required = result["required"].as_array().unwrap();
+        assert!(required.contains(&json!("stable")));
+        assert!(!required.contains(&json!("planned")));
+        assert!(!required.contains(&json!("legacy")));
     }
 
     #[test]

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -368,10 +368,8 @@ fn resolve_properties(
                 // Include future fields: currently omit but transitioning to non-omit.
                 // Completes transition lifecycle symmetry — deprecations (to=omit) are
                 // already surfaced; this surfaces planned additions (from=omit).
-                let is_future = options.include_future
-                    && transition
-                        .as_ref()
-                        .map_or(false, |t| t.to != "omit");
+                let is_future =
+                    options.include_future && transition.as_ref().is_some_and(|t| t.to != "omit");
 
                 if is_future {
                     let resolved = resolve_value(prop_value, options, &prop_path)?;
@@ -1141,16 +1139,24 @@ mod tests {
 
         // stable: present, no transition
         assert!(result["properties"].get("stable").is_some());
-        assert!(result["properties"]["stable"].get("x-ucp-schema-transition").is_none());
+        assert!(result["properties"]["stable"]
+            .get("x-ucp-schema-transition")
+            .is_none());
 
         // planned: present via include_future, transition metadata, not deprecated
         assert!(result["properties"].get("planned").is_some());
-        assert_eq!(result["properties"]["planned"]["x-ucp-schema-transition"]["from"], "omit");
+        assert_eq!(
+            result["properties"]["planned"]["x-ucp-schema-transition"]["from"],
+            "omit"
+        );
         assert!(result["properties"]["planned"].get("deprecated").is_none());
 
         // legacy: present (from=optional), transition metadata, deprecated=true
         assert!(result["properties"].get("legacy").is_some());
-        assert_eq!(result["properties"]["legacy"]["x-ucp-schema-transition"]["to"], "omit");
+        assert_eq!(
+            result["properties"]["legacy"]["x-ucp-schema-transition"]["to"],
+            "omit"
+        );
         assert_eq!(result["properties"]["legacy"]["deprecated"], true);
 
         // required: only stable (planned is omit-visibility, legacy is optional)

--- a/src/types.rs
+++ b/src/types.rs
@@ -106,6 +106,12 @@ pub struct ResolveOptions {
     /// When true, sets `additionalProperties: false` on all object schemas
     /// to reject unknown fields. Defaults to false to respect schema extensibility.
     pub strict: bool,
+    /// When true, includes fields with `omit` visibility that have a transition
+    /// targeting a non-omit value (i.e., planned additions). These fields appear
+    /// in the resolved output with `x-ucp-schema-transition` metadata but are NOT
+    /// added to `required`. Completes the lifecycle symmetry: deprecations (to=omit)
+    /// are always surfaced; this flag surfaces planned additions (from=omit) too.
+    pub include_future: bool,
 }
 
 impl ResolveOptions {
@@ -119,12 +125,19 @@ impl ResolveOptions {
             direction,
             operation: operation.into().to_lowercase(),
             strict: false,
+            include_future: false,
         }
     }
 
     /// Set strict mode (additionalProperties: false on all objects).
     pub fn strict(mut self, strict: bool) -> Self {
         self.strict = strict;
+        self
+    }
+
+    /// Include future fields (omit-visibility with non-omit transition target).
+    pub fn include_future(mut self, include_future: bool) -> Self {
+        self.include_future = include_future;
         self
     }
 }


### PR DESCRIPTION
Resolver already surfaces **deprecations** — fields transitioning *to* `omit` appear in resolved output with `x-ucp-schema-transition` metadata and `deprecated: true`. This lets documentation generators and migration tools show "this field is going away." The inverse is missing: fields transitioning *from* `omit` (planned additions) are silently dropped. 

When `--include-future` is set, fields with `omit` visibility that have a transition targeting a non-omit value are included in resolved output. They are **not** added to `required` — current visibility remains `omit`. They carry `x-ucp-schema-transition` metadata just like deprecations. **Default behavior is unchanged (backward compatible).**

Transition system now covers the full field lifecycle:

| Direction | Source field | Resolved behavior |
|-----------|------------|-------------------|
| **Deprecation** (to=omit) | `"transition": { "from": "required", "to": "omit" }` | Always surfaced, `deprecated: true` + transition metadata |
| **Future addition** (from=omit) | `"transition": { "from": "omit", "to": "required" }` | Surfaced only with `--include-future`, transition metadata only |

## Example

A schema planning to add a `gift_message` field in a future version:

```json
"gift_message": {
  "type": "string",
  "description": "Optional message included with gift orders.",
  "ucp_request": {
    "transition": {
      "from": "omit",
      "to": "optional",
      "description": "Planned for 2026-04 release."
    }
  }
}
```

Without `--include-future` (default): `gift_message` is absent from resolved output. With `--include-future`:

```json
"gift_message": {
  "type": "string",
  "description": "Optional message included with gift orders.",
  "x-ucp-schema-transition": {
    "from": "omit",
    "to": "optional",
    "description": "Planned for 2026-04 release."
  }
}
```



Present in `properties`, absent from `required`. Platforms and tooling can use this to prepare for upcoming schema changes before they land.


## Checklist
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md).
- [x] My changes pass all local linting and formatting checks.
