### PR TITLE
feat: validate `requires` constraints on extension schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,15 +161,19 @@ Options:
   --quiet, -q           Only show errors, suppress progress
 ```
 
-| Category    | Issue                                                        | Severity |
-| ----------- | ------------------------------------------------------------ | -------- |
-| Syntax      | Invalid JSON                                                 | Error    |
-| References  | `$ref` to missing file                                       | Error    |
-| References  | `$ref` to missing anchor (`#/$defs/foo`)                     | Error    |
-| Annotations | Invalid `ucp_*` type (must be string or object)              | Error    |
-| Annotations | Invalid visibility value (must be omit/required/optional)    | Error    |
-| Hygiene     | Missing `$id` field                                          | Warning  |
-| Hygiene     | Unknown operation in annotation (e.g., `{"delete": "omit"}`) | Warning  |
+| Code | Category    | Issue                                                        | Severity |
+| ---- | ----------- | ------------------------------------------------------------ | -------- |
+| E001 | Syntax      | Invalid JSON                                                 | Error    |
+| E002 | References  | `$ref` to missing file                                       | Error    |
+| E003 | References  | `$ref` to missing anchor (`#/$defs/foo`)                     | Error    |
+| E004 | Annotations | Invalid visibility value or schema transition                | Error    |
+| E005 | Annotations | Invalid `ucp_*` type (must be string or object)              | Error    |
+| E006 | Requires    | Invalid `requires` structure (wrong types, bad version format) | Error  |
+| E007 | Requires    | `requires.capabilities` key not found in `$defs`             | Error    |
+| W002 | Hygiene     | Missing `$id` field                                          | Warning  |
+| W003 | Hygiene     | Unknown operation in annotation (e.g., `{"delete": "omit"}`) | Warning  |
+| W004 | Requires    | Version constraint has `min` > `max`                         | Warning  |
+| W005 | Requires    | Unknown key in `requires` or version constraint              | Warning  |
 
 ```bash
 # Lint a directory of schemas
@@ -388,6 +392,28 @@ Extension schemas define their additions in `$defs` keyed by the root capability
   }
 }
 ```
+
+**Version constraints (`requires`):**
+
+Extension schemas can declare which protocol and capability versions they depend on. Composition fails if the declared constraints are not satisfied by the profile's versions:
+
+```json
+{
+  "$id": "https://acme.com/ucp/schemas/loyalty.json",
+  "name": "com.acme.shopping.loyalty",
+  "requires": {
+    "protocol": { "min": "2026-01-23" },
+    "capabilities": {
+      "dev.ucp.shopping.checkout": { "min": "2026-06-01" }
+    }
+  },
+  "$defs": {
+    "dev.ucp.shopping.checkout": { ... }
+  }
+}
+```
+
+Each constraint is an object with a required `min` and optional `max` (both inclusive). Keys in `requires.capabilities` must be a subset of `$defs` keys. Schemas without `requires` compose as before — the composer asserts compatibility.
 
 ### Validation Modes
 

--- a/README.md
+++ b/README.md
@@ -161,19 +161,19 @@ Options:
   --quiet, -q           Only show errors, suppress progress
 ```
 
-| Code | Category    | Issue                                                        | Severity |
-| ---- | ----------- | ------------------------------------------------------------ | -------- |
-| E001 | Syntax      | Invalid JSON                                                 | Error    |
-| E002 | References  | `$ref` to missing file                                       | Error    |
-| E003 | References  | `$ref` to missing anchor (`#/$defs/foo`)                     | Error    |
-| E004 | Annotations | Invalid visibility value or schema transition                | Error    |
-| E005 | Annotations | Invalid `ucp_*` type (must be string or object)              | Error    |
-| E006 | Requires    | Invalid `requires` structure (wrong types, bad version format) | Error  |
-| E007 | Requires    | `requires.capabilities` key not found in `$defs`             | Error    |
-| W002 | Hygiene     | Missing `$id` field                                          | Warning  |
-| W003 | Hygiene     | Unknown operation in annotation (e.g., `{"delete": "omit"}`) | Warning  |
-| W004 | Requires    | Version constraint has `min` > `max`                         | Warning  |
-| W005 | Requires    | Unknown key in `requires` or version constraint              | Warning  |
+| Code | Category    | Issue                                                          | Severity |
+| ---- | ----------- | -------------------------------------------------------------- | -------- |
+| E001 | Syntax      | Invalid JSON                                                   | Error    |
+| E002 | References  | `$ref` to missing file                                         | Error    |
+| E003 | References  | `$ref` to missing anchor (`#/$defs/foo`)                       | Error    |
+| E004 | Annotations | Invalid visibility value or schema transition                  | Error    |
+| E005 | Annotations | Invalid `ucp_*` type (must be string or object)                | Error    |
+| E006 | Requires    | Invalid `requires` structure (wrong types, bad version format) | Error    |
+| E007 | Requires    | `requires.capabilities` key not found in `$defs`               | Error    |
+| W002 | Hygiene     | Missing `$id` field                                            | Warning  |
+| W003 | Hygiene     | Unknown operation in annotation (e.g., `{"delete": "omit"}`)   | Warning  |
+| W004 | Requires    | Version constraint has `min` > `max`                           | Warning  |
+| W005 | Requires    | Unknown key in `requires` or version constraint                | Warning  |
 
 ```bash
 # Lint a directory of schemas

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -45,7 +45,7 @@ use serde_json::{json, Value};
 
 use crate::error::ComposeError;
 use crate::loader::{bundle_refs, bundle_refs_with_url_mapping, is_url, load_schema};
-use crate::types::Direction;
+use crate::types::{Direction, Requires, VersionConstraint};
 
 #[cfg(feature = "remote")]
 use crate::loader::{bundle_refs_remote, load_schema_url};
@@ -304,6 +304,97 @@ fn fetch_profile(url: &str, schema_base: &SchemaBaseConfig) -> Result<Value, Com
     })
 }
 
+/// A version constraint violation found during composition.
+#[derive(Debug, Clone)]
+pub struct VersionViolation {
+    /// The extension that declared the constraint.
+    pub extension: String,
+    /// What was constrained ("protocol" or capability name).
+    pub target: String,
+    /// The declared constraint.
+    pub constraint: VersionConstraint,
+    /// The actual version found.
+    pub actual: String,
+}
+
+impl VersionViolation {
+    /// Format the constraint as a human-readable range string.
+    pub fn range_display(&self) -> String {
+        match &self.constraint.max {
+            Some(max) => format!("[{}, {}]", self.constraint.min, max),
+            None => format!(">= {}", self.constraint.min),
+        }
+    }
+}
+
+impl std::fmt::Display for VersionViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "extension '{}' requires {} {} but found {}",
+            self.extension,
+            self.target,
+            self.range_display(),
+            self.actual
+        )
+    }
+}
+
+/// Check an extension schema's `requires` constraints against the available versions.
+///
+/// Returns a list of violations (empty if all constraints are satisfied).
+pub fn check_version_constraints(
+    extension_name: &str,
+    extension_schema: &Value,
+    protocol_version: Option<&str>,
+    capabilities: &[Capability],
+) -> Vec<VersionViolation> {
+    let Some(requires_val) = extension_schema.get("requires") else {
+        return vec![];
+    };
+
+    let requires = match Requires::parse(requires_val) {
+        Ok(r) => r,
+        Err(_) => return vec![], // Malformed requires is a lint error, not a compose error
+    };
+
+    let mut violations = Vec::new();
+
+    // Check protocol constraint
+    if let (Some(ref constraint), Some(version)) = (&requires.protocol, protocol_version) {
+        if !constraint.satisfied_by(version) {
+            violations.push(VersionViolation {
+                extension: extension_name.to_string(),
+                target: "protocol".to_string(),
+                constraint: constraint.clone(),
+                actual: version.to_string(),
+            });
+        }
+    }
+
+    // Check capability constraints
+    let cap_versions: HashMap<&str, &str> = capabilities
+        .iter()
+        .map(|c| (c.name.as_str(), c.version.as_str()))
+        .collect();
+
+    for (cap_name, constraint) in &requires.capabilities {
+        if let Some(&version) = cap_versions.get(cap_name.as_str()) {
+            if !constraint.satisfied_by(version) {
+                violations.push(VersionViolation {
+                    extension: extension_name.to_string(),
+                    target: cap_name.clone(),
+                    constraint: constraint.clone(),
+                    actual: version.to_string(),
+                });
+            }
+        }
+        // If capability isn't in the list, it won't be composed — not our problem
+    }
+
+    violations
+}
+
 /// Compose schema from capability declarations.
 ///
 /// 1. Finds root capability (no extends)
@@ -388,6 +479,19 @@ pub fn compose_schema(
                 message: e.to_string(),
             }
         })?;
+
+        // Check version constraints: if requires is declared and violated, fail.
+        // No requires = backwards compat (composer asserts compatibility).
+        let violations =
+            check_version_constraints(&ext.name, &ext_schema, Some(&root.version), capabilities);
+        if let Some(v) = violations.first() {
+            return Err(ComposeError::VersionConstraintViolation {
+                extension: v.extension.clone(),
+                target: v.target.clone(),
+                range: v.range_display(),
+                actual: v.actual.clone(),
+            });
+        }
 
         // Extract $defs[root.name] and inline any internal refs
         let defs = ext_schema
@@ -1050,5 +1154,368 @@ mod tests {
 
         let result = extract_jsonrpc_payload(&envelope, &capabilities);
         assert!(matches!(result, Err(ComposeError::InvalidEnvelope { .. })));
+    }
+
+    // -- compose_schema version constraint integration tests --
+
+    #[test]
+    fn compose_rejects_violated_protocol_constraint() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Root schema
+        let checkout_path = dir.path().join("checkout.json");
+        std::fs::write(
+            &checkout_path,
+            r#"{"type": "object", "properties": {"id": {"type": "string"}}}"#,
+        )
+        .unwrap();
+
+        // Extension schema with requires.protocol that won't be satisfied
+        let ext_path = dir.path().join("loyalty.json");
+        std::fs::write(
+            &ext_path,
+            r#"{
+                "requires": { "protocol": { "min": "2026-09-01" } },
+                "$defs": {
+                    "dev.ucp.shopping.checkout": {
+                        "type": "object",
+                        "properties": { "loyalty": { "type": "integer" } }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let capabilities = vec![
+            Capability {
+                name: "dev.ucp.shopping.checkout".to_string(),
+                version: "2026-06-01".to_string(),
+                schema_url: checkout_path.to_str().unwrap().to_string(),
+                extends: None,
+            },
+            Capability {
+                name: "com.acme.loyalty".to_string(),
+                version: "2026-01-01".to_string(),
+                schema_url: ext_path.to_str().unwrap().to_string(),
+                extends: Some(vec!["dev.ucp.shopping.checkout".to_string()]),
+            },
+        ];
+
+        let config = SchemaBaseConfig::default();
+        let result = compose_schema(&capabilities, &config);
+        assert!(
+            matches!(result, Err(ComposeError::VersionConstraintViolation { .. })),
+            "expected VersionConstraintViolation, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn compose_rejects_violated_capability_constraint() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let checkout_path = dir.path().join("checkout.json");
+        std::fs::write(
+            &checkout_path,
+            r#"{"type": "object", "properties": {"id": {"type": "string"}}}"#,
+        )
+        .unwrap();
+
+        // Extension requires checkout >= 2026-09-01 but profile has 2026-06-01
+        let ext_path = dir.path().join("loyalty.json");
+        std::fs::write(
+            &ext_path,
+            r#"{
+                "requires": {
+                    "capabilities": {
+                        "dev.ucp.shopping.checkout": { "min": "2026-09-01" }
+                    }
+                },
+                "$defs": {
+                    "dev.ucp.shopping.checkout": {
+                        "type": "object",
+                        "properties": { "loyalty": { "type": "integer" } }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let capabilities = vec![
+            Capability {
+                name: "dev.ucp.shopping.checkout".to_string(),
+                version: "2026-06-01".to_string(),
+                schema_url: checkout_path.to_str().unwrap().to_string(),
+                extends: None,
+            },
+            Capability {
+                name: "com.acme.loyalty".to_string(),
+                version: "2026-01-01".to_string(),
+                schema_url: ext_path.to_str().unwrap().to_string(),
+                extends: Some(vec!["dev.ucp.shopping.checkout".to_string()]),
+            },
+        ];
+
+        let config = SchemaBaseConfig::default();
+        let result = compose_schema(&capabilities, &config);
+        match &result {
+            Err(ComposeError::VersionConstraintViolation {
+                extension, target, ..
+            }) => {
+                assert_eq!(extension, "com.acme.loyalty");
+                assert_eq!(target, "dev.ucp.shopping.checkout");
+            }
+            other => panic!("expected VersionConstraintViolation, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn compose_succeeds_when_constraints_satisfied() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let checkout_path = dir.path().join("checkout.json");
+        std::fs::write(
+            &checkout_path,
+            r#"{"type": "object", "properties": {"id": {"type": "string"}}}"#,
+        )
+        .unwrap();
+
+        // Extension requires checkout >= 2026-01-23, profile has 2026-06-01 — satisfied
+        let ext_path = dir.path().join("loyalty.json");
+        std::fs::write(
+            &ext_path,
+            r#"{
+                "requires": {
+                    "protocol": { "min": "2026-01-23" },
+                    "capabilities": {
+                        "dev.ucp.shopping.checkout": { "min": "2026-01-23" }
+                    }
+                },
+                "$defs": {
+                    "dev.ucp.shopping.checkout": {
+                        "type": "object",
+                        "properties": { "loyalty": { "type": "integer" } }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let capabilities = vec![
+            Capability {
+                name: "dev.ucp.shopping.checkout".to_string(),
+                version: "2026-06-01".to_string(),
+                schema_url: checkout_path.to_str().unwrap().to_string(),
+                extends: None,
+            },
+            Capability {
+                name: "com.acme.loyalty".to_string(),
+                version: "2026-01-01".to_string(),
+                schema_url: ext_path.to_str().unwrap().to_string(),
+                extends: Some(vec!["dev.ucp.shopping.checkout".to_string()]),
+            },
+        ];
+
+        let config = SchemaBaseConfig::default();
+        let result = compose_schema(&capabilities, &config);
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+    }
+
+    #[test]
+    fn compose_succeeds_without_requires() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let checkout_path = dir.path().join("checkout.json");
+        std::fs::write(
+            &checkout_path,
+            r#"{"type": "object", "properties": {"id": {"type": "string"}}}"#,
+        )
+        .unwrap();
+
+        // No requires — backwards compat
+        let ext_path = dir.path().join("discount.json");
+        std::fs::write(
+            &ext_path,
+            r#"{
+                "$defs": {
+                    "dev.ucp.shopping.checkout": {
+                        "type": "object",
+                        "properties": { "discounts": { "type": "array" } }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let capabilities = vec![
+            Capability {
+                name: "dev.ucp.shopping.checkout".to_string(),
+                version: "2026-06-01".to_string(),
+                schema_url: checkout_path.to_str().unwrap().to_string(),
+                extends: None,
+            },
+            Capability {
+                name: "dev.ucp.shopping.discount".to_string(),
+                version: "2026-06-01".to_string(),
+                schema_url: ext_path.to_str().unwrap().to_string(),
+                extends: Some(vec!["dev.ucp.shopping.checkout".to_string()]),
+            },
+        ];
+
+        let config = SchemaBaseConfig::default();
+        let result = compose_schema(&capabilities, &config);
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+    }
+
+    // -- Version constraint checking (standalone function) tests --
+
+    fn make_capabilities() -> Vec<Capability> {
+        vec![
+            Capability {
+                name: "dev.ucp.shopping.checkout".to_string(),
+                version: "2026-06-01".to_string(),
+                schema_url: "https://example.com/checkout.json".to_string(),
+                extends: None,
+            },
+            Capability {
+                name: "dev.ucp.shopping.fulfillment".to_string(),
+                version: "2026-03-01".to_string(),
+                schema_url: "https://example.com/fulfillment.json".to_string(),
+                extends: Some(vec!["dev.ucp.shopping.checkout".to_string()]),
+            },
+        ]
+    }
+
+    #[test]
+    fn version_constraints_satisfied() {
+        let caps = make_capabilities();
+        let schema = json!({
+            "requires": {
+                "protocol": { "min": "2026-01-23" },
+                "capabilities": {
+                    "dev.ucp.shopping.checkout": { "min": "2026-01-23" }
+                }
+            }
+        });
+
+        let violations =
+            check_version_constraints("com.acme.loyalty", &schema, Some("2026-06-01"), &caps);
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn version_constraints_protocol_violation() {
+        let caps = make_capabilities();
+        let schema = json!({
+            "requires": {
+                "protocol": { "min": "2026-09-01" }
+            }
+        });
+
+        let violations =
+            check_version_constraints("com.acme.loyalty", &schema, Some("2026-06-01"), &caps);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].target, "protocol");
+    }
+
+    #[test]
+    fn version_constraints_capability_violation() {
+        let caps = make_capabilities();
+        let schema = json!({
+            "requires": {
+                "capabilities": {
+                    "dev.ucp.shopping.checkout": { "min": "2026-09-01" }
+                }
+            }
+        });
+
+        let violations =
+            check_version_constraints("com.acme.loyalty", &schema, Some("2026-06-01"), &caps);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].target, "dev.ucp.shopping.checkout");
+        assert_eq!(violations[0].actual, "2026-06-01");
+    }
+
+    #[test]
+    fn version_constraints_max_exceeded() {
+        let caps = make_capabilities();
+        let schema = json!({
+            "requires": {
+                "capabilities": {
+                    "dev.ucp.shopping.checkout": {
+                        "min": "2026-01-23",
+                        "max": "2026-03-01"
+                    }
+                }
+            }
+        });
+
+        let violations =
+            check_version_constraints("com.acme.loyalty", &schema, Some("2026-06-01"), &caps);
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0]
+            .to_string()
+            .contains("[2026-01-23, 2026-03-01]"));
+    }
+
+    #[test]
+    fn version_constraints_no_requires() {
+        let caps = make_capabilities();
+        let schema = json!({ "type": "object" });
+
+        let violations =
+            check_version_constraints("com.acme.loyalty", &schema, Some("2026-06-01"), &caps);
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn version_constraints_no_protocol_version() {
+        // Protocol constraint present but no protocol version provided — skip check
+        let caps = make_capabilities();
+        let schema = json!({
+            "requires": {
+                "protocol": { "min": "2026-09-01" }
+            }
+        });
+
+        let violations = check_version_constraints("com.acme.loyalty", &schema, None, &caps);
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn version_constraints_multiple_violations() {
+        let caps = make_capabilities();
+        let schema = json!({
+            "requires": {
+                "protocol": { "min": "2026-09-01" },
+                "capabilities": {
+                    "dev.ucp.shopping.checkout": { "min": "2026-09-01" }
+                }
+            }
+        });
+
+        let violations =
+            check_version_constraints("com.acme.loyalty", &schema, Some("2026-06-01"), &caps);
+        assert_eq!(violations.len(), 2);
+        let targets: Vec<&str> = violations.iter().map(|v| v.target.as_str()).collect();
+        assert!(targets.contains(&"protocol"));
+        assert!(targets.contains(&"dev.ucp.shopping.checkout"));
+    }
+
+    #[test]
+    fn version_constraints_unknown_capability() {
+        // Constraint on a capability not in the list — no violation (not our problem)
+        let caps = make_capabilities();
+        let schema = json!({
+            "requires": {
+                "capabilities": {
+                    "dev.ucp.shopping.order": { "min": "2026-01-23" }
+                }
+            }
+        });
+
+        let violations =
+            check_version_constraints("com.acme.loyalty", &schema, Some("2026-06-01"), &caps);
+        assert!(violations.is_empty());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,14 @@ pub enum ComposeError {
 
     #[error("invalid URL '{url}': {message}")]
     InvalidUrl { url: String, message: String },
+
+    #[error("extension '{extension}' requires {target} {range} but found {actual}")]
+    VersionConstraintViolation {
+        extension: String,
+        target: String,
+        range: String,
+        actual: String,
+    },
 }
 
 impl ComposeError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,9 @@ mod types;
 mod validator;
 
 pub use compose::{
-    capability_short_name, compose_from_payload, compose_schema, detect_direction,
-    extract_capabilities, extract_capabilities_from_profile, extract_jsonrpc_payload, Capability,
-    DetectedDirection, SchemaBaseConfig,
+    capability_short_name, check_version_constraints, compose_from_payload, compose_schema,
+    detect_direction, extract_capabilities, extract_capabilities_from_profile,
+    extract_jsonrpc_payload, Capability, DetectedDirection, SchemaBaseConfig, VersionViolation,
 };
 pub use error::{ComposeError, ResolveError, SchemaError, ValidateError};
 pub use linter::{lint, lint_file, Diagnostic, FileResult, FileStatus, LintResult, Severity};
@@ -74,7 +74,7 @@ pub use loader::{
     load_schema_str, navigate_fragment,
 };
 pub use resolver::{resolve, strip_annotations};
-pub use types::{Direction, ResolveOptions, Visibility};
+pub use types::{Direction, Requires, ResolveOptions, VersionConstraint, Visibility};
 pub use validator::{validate, validate_against_schema};
 
 #[cfg(feature = "remote")]

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -12,7 +12,8 @@ use serde_json::Value;
 
 use crate::loader::{load_schema, navigate_fragment};
 use crate::types::{
-    is_valid_schema_transition, json_type_name, Visibility, UCP_ANNOTATIONS, VALID_OPERATIONS,
+    is_valid_schema_transition, is_valid_version, json_type_name, VersionConstraint, Visibility,
+    UCP_ANNOTATIONS, VALID_OPERATIONS,
 };
 
 /// Severity level for diagnostics.
@@ -151,6 +152,9 @@ pub fn lint_file(file: &Path, base_path: &Path) -> FileResult {
 
     // Check ucp_* annotations
     check_annotations(&schema, file, "", &mut diagnostics);
+
+    // Check `requires` field (version constraints on extension schemas)
+    check_requires(&schema, file, &mut diagnostics);
 
     // Check for missing $id (warning)
     if schema.get("$id").is_none() {
@@ -475,6 +479,229 @@ fn check_transition_object(
                 key, from, to
             ),
         });
+    }
+}
+
+/// Validate a `version_constraint` object at the given path.
+/// Returns the parsed constraint on success for further checks.
+fn check_version_constraint(
+    value: &Value,
+    file: &Path,
+    path: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<VersionConstraint> {
+    let obj = match value.as_object() {
+        Some(o) => o,
+        None => {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Error,
+                code: "E006".to_string(),
+                file: file.to_path_buf(),
+                path: path.to_string(),
+                message: format!(
+                    "invalid version constraint: expected object, got {}",
+                    json_type_name(value)
+                ),
+            });
+            return None;
+        }
+    };
+
+    // Warn about unknown keys (catch typos like "maxx")
+    const KNOWN_CONSTRAINT_KEYS: &[&str] = &["min", "max"];
+    for key in obj.keys() {
+        if !KNOWN_CONSTRAINT_KEYS.contains(&key.as_str()) {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Warning,
+                code: "W005".to_string(),
+                file: file.to_path_buf(),
+                path: format!("{}/{}", path, key),
+                message: format!(
+                    "unknown key \"{}\" in version constraint: expected min, max",
+                    key
+                ),
+            });
+        }
+    }
+
+    let min = match obj.get("min").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Error,
+                code: "E006".to_string(),
+                file: file.to_path_buf(),
+                path: path.to_string(),
+                message: "version constraint missing required field \"min\"".to_string(),
+            });
+            return None;
+        }
+    };
+
+    if !is_valid_version(min) {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Error,
+            code: "E006".to_string(),
+            file: file.to_path_buf(),
+            path: format!("{}/min", path),
+            message: format!("invalid version format \"{}\": expected YYYY-MM-DD", min),
+        });
+        return None;
+    }
+
+    let mut max_str = None;
+    if let Some(max_val) = obj.get("max") {
+        match max_val.as_str() {
+            Some(s) => {
+                if !is_valid_version(s) {
+                    diagnostics.push(Diagnostic {
+                        severity: Severity::Error,
+                        code: "E006".to_string(),
+                        file: file.to_path_buf(),
+                        path: format!("{}/max", path),
+                        message: format!("invalid version format \"{}\": expected YYYY-MM-DD", s),
+                    });
+                    return None;
+                }
+                max_str = Some(s.to_string());
+            }
+            None => {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    code: "E006".to_string(),
+                    file: file.to_path_buf(),
+                    path: format!("{}/max", path),
+                    message: "\"max\" must be a string".to_string(),
+                });
+                return None;
+            }
+        }
+    }
+
+    let vc = VersionConstraint {
+        min: min.to_string(),
+        max: max_str,
+    };
+
+    // Warn if min > max (likely authoring error)
+    if let Some(ref max) = vc.max {
+        if vc.min.as_str() > max.as_str() {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Warning,
+                code: "W004".to_string(),
+                file: file.to_path_buf(),
+                path: path.to_string(),
+                message: format!("version constraint has min ({}) > max ({})", vc.min, max),
+            });
+        }
+    }
+
+    Some(vc)
+}
+
+/// Validate the top-level `requires` field on an extension schema.
+///
+/// Checks:
+/// - E006: Invalid structure (wrong types, bad version format)
+/// - E007: `requires.capabilities` key not found in `$defs`
+/// - W004: `min` > `max` in a version constraint
+fn check_requires(schema: &Value, file: &Path, diagnostics: &mut Vec<Diagnostic>) {
+    let Some(requires) = schema.get("requires") else {
+        return;
+    };
+
+    let requires_path = "/requires";
+
+    let obj = match requires.as_object() {
+        Some(o) => o,
+        None => {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Error,
+                code: "E006".to_string(),
+                file: file.to_path_buf(),
+                path: requires_path.to_string(),
+                message: format!(
+                    "\"requires\" must be an object, got {}",
+                    json_type_name(requires)
+                ),
+            });
+            return;
+        }
+    };
+
+    // Warn about unknown keys (catch typos like "protocl")
+    const KNOWN_REQUIRES_KEYS: &[&str] = &["protocol", "capabilities"];
+    for key in obj.keys() {
+        if !KNOWN_REQUIRES_KEYS.contains(&key.as_str()) {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Warning,
+                code: "W005".to_string(),
+                file: file.to_path_buf(),
+                path: format!("{}/{}", requires_path, key),
+                message: format!(
+                    "unknown key \"{}\" in requires: expected protocol, capabilities",
+                    key
+                ),
+            });
+        }
+    }
+
+    // Validate requires.protocol
+    if let Some(protocol) = obj.get("protocol") {
+        check_version_constraint(
+            protocol,
+            file,
+            &format!("{}/protocol", requires_path),
+            diagnostics,
+        );
+    }
+
+    // Validate requires.capabilities
+    if let Some(caps) = obj.get("capabilities") {
+        let caps_path = format!("{}/capabilities", requires_path);
+        let caps_obj = match caps.as_object() {
+            Some(o) => o,
+            None => {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    code: "E006".to_string(),
+                    file: file.to_path_buf(),
+                    path: caps_path,
+                    message: format!(
+                        "\"requires.capabilities\" must be an object, got {}",
+                        json_type_name(caps)
+                    ),
+                });
+                return;
+            }
+        };
+
+        // Collect $defs keys for cross-reference check
+        let defs_keys: std::collections::HashSet<&str> = schema
+            .get("$defs")
+            .and_then(|d| d.as_object())
+            .map(|d| d.keys().map(|k| k.as_str()).collect())
+            .unwrap_or_default();
+
+        for (cap_name, constraint) in caps_obj {
+            let cap_path = format!("{}/{}", caps_path, cap_name);
+
+            check_version_constraint(constraint, file, &cap_path, diagnostics);
+
+            // Cross-reference: capability key must exist in $defs
+            if !defs_keys.contains(cap_name.as_str()) {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    code: "E007".to_string(),
+                    file: file.to_path_buf(),
+                    path: cap_path,
+                    message: format!(
+                        "requires.capabilities key \"{}\" not found in $defs",
+                        cap_name
+                    ),
+                });
+            }
+        }
     }
 }
 
@@ -823,6 +1050,251 @@ mod tests {
         .unwrap();
 
         let result = lint_file(&main_path, dir.path());
+        assert_eq!(result.status, FileStatus::Ok);
+    }
+
+    #[test]
+    fn lint_valid_requires() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/loyalty.json",
+            "requires": {{
+                "protocol": {{ "min": "2026-01-23" }},
+                "capabilities": {{
+                    "dev.ucp.shopping.checkout": {{ "min": "2026-06-01" }}
+                }}
+            }},
+            "$defs": {{
+                "dev.ucp.shopping.checkout": {{ "type": "object" }}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Ok);
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn lint_requires_with_range() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/loyalty.json",
+            "requires": {{
+                "protocol": {{ "min": "2026-01-23", "max": "2026-09-01" }}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Ok);
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn lint_requires_not_object() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "requires": "bad"
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Error);
+        assert!(result.diagnostics.iter().any(|d| d.code == "E006"));
+    }
+
+    #[test]
+    fn lint_requires_bad_version_format() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "requires": {{
+                "protocol": {{ "min": "not-a-date" }}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Error);
+        assert!(result.diagnostics.iter().any(|d| d.code == "E006"));
+    }
+
+    #[test]
+    fn lint_requires_missing_min() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "requires": {{
+                "protocol": {{ "max": "2026-09-01" }}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Error);
+        assert!(result
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "E006" && d.message.contains("min")));
+    }
+
+    #[test]
+    fn lint_requires_min_greater_than_max() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "requires": {{
+                "protocol": {{ "min": "2026-09-01", "max": "2026-01-23" }}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert!(result.diagnostics.iter().any(|d| d.code == "W004"));
+    }
+
+    #[test]
+    fn lint_requires_capability_not_in_defs() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/loyalty.json",
+            "requires": {{
+                "capabilities": {{
+                    "dev.ucp.shopping.checkout": {{ "min": "2026-06-01" }}
+                }}
+            }},
+            "$defs": {{
+                "dev.ucp.shopping.order": {{ "type": "object" }}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Error);
+        assert!(result.diagnostics.iter().any(|d| d.code == "E007"));
+    }
+
+    #[test]
+    fn lint_requires_capability_no_defs() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "requires": {{
+                "capabilities": {{
+                    "dev.ucp.shopping.checkout": {{ "min": "2026-06-01" }}
+                }}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Error);
+        assert!(result.diagnostics.iter().any(|d| d.code == "E007"));
+    }
+
+    #[test]
+    fn lint_requires_unknown_key_in_requires() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "requires": {{
+                "protocl": {{ "min": "2026-01-23" }}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert!(result
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "W005" && d.message.contains("protocl")));
+    }
+
+    #[test]
+    fn lint_requires_unknown_key_in_constraint() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "requires": {{
+                "protocol": {{ "min": "2026-01-23", "maxx": "2026-09-01" }}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert!(result
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "W005" && d.message.contains("maxx")));
+    }
+
+    #[test]
+    fn lint_requires_empty_capabilities_ok() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "requires": {{
+                "capabilities": {{}}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Ok);
+    }
+
+    #[test]
+    fn lint_schema_without_requires_unchanged() {
+        // Backwards compat: schemas without `requires` pass unchanged
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "type": "object",
+            "properties": {{
+                "id": {{ "type": "string" }}
+            }}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
         assert_eq!(result.status, FileStatus::Ok);
     }
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -629,7 +629,7 @@ fn check_requires(schema: &Value, file: &Path, diagnostics: &mut Vec<Diagnostic>
         }
     };
 
-    // Warn about unknown keys (catch typos like "protocl")
+    // Warn about unknown keys (catch typos)
     const KNOWN_REQUIRES_KEYS: &[&str] = &["protocol", "capabilities"];
     for key in obj.keys() {
         if !KNOWN_REQUIRES_KEYS.contains(&key.as_str()) {
@@ -1226,7 +1226,7 @@ mod tests {
             r#"{{
             "$id": "https://example.com/test.json",
             "requires": {{
-                "protocl": {{ "min": "2026-01-23" }}
+                "proto_version": {{ "min": "2026-01-23" }}
             }}
         }}"#
         )
@@ -1236,7 +1236,7 @@ mod tests {
         assert!(result
             .diagnostics
             .iter()
-            .any(|d| d.code == "W005" && d.message.contains("protocl")));
+            .any(|d| d.code == "W005" && d.message.contains("proto_version")));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -95,6 +95,145 @@ pub fn is_valid_schema_transition(from: &str, to: &str) -> bool {
     from != to && Visibility::parse(from).is_some() && Visibility::parse(to).is_some()
 }
 
+// ---------------------------------------------------------------------------
+// Version constraints (`requires` on extension schemas)
+// ---------------------------------------------------------------------------
+
+/// Check if a string is a valid UCP version (YYYY-MM-DD with valid month/day).
+pub fn is_valid_version(s: &str) -> bool {
+    if s.len() != 10 || s.as_bytes()[4] != b'-' || s.as_bytes()[7] != b'-' {
+        return false;
+    }
+    if !s.bytes().enumerate().all(|(i, b)| {
+        if i == 4 || i == 7 {
+            b == b'-'
+        } else {
+            b.is_ascii_digit()
+        }
+    }) {
+        return false;
+    }
+    let month: u8 = s[5..7].parse().unwrap_or(0);
+    let day: u8 = s[8..10].parse().unwrap_or(0);
+    (1..=12).contains(&month) && (1..=31).contains(&day)
+}
+
+/// Version range: minimum (required) and optional maximum, both inclusive.
+///
+/// Date-based versions (YYYY-MM-DD) are lexicographically orderable,
+/// so constraint checking is simple string comparison.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionConstraint {
+    pub min: String,
+    pub max: Option<String>,
+}
+
+impl VersionConstraint {
+    /// Check if a version satisfies this constraint.
+    pub fn satisfied_by(&self, version: &str) -> bool {
+        if version < self.min.as_str() {
+            return false;
+        }
+        if let Some(ref max) = self.max {
+            if version > max.as_str() {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Parse from a JSON value: `{ "min": "...", "max": "..." }`.
+    pub fn parse(value: &Value) -> Result<Self, String> {
+        let obj = value.as_object().ok_or("expected object")?;
+
+        let min = obj
+            .get("min")
+            .and_then(|v| v.as_str())
+            .ok_or("missing required field \"min\"")?;
+
+        if !is_valid_version(min) {
+            return Err(format!(
+                "invalid version format for \"min\": \"{}\" (expected YYYY-MM-DD)",
+                min
+            ));
+        }
+
+        let max = match obj.get("max") {
+            Some(v) => {
+                let s = v.as_str().ok_or("\"max\" must be a string")?;
+                if !is_valid_version(s) {
+                    return Err(format!(
+                        "invalid version format for \"max\": \"{}\" (expected YYYY-MM-DD)",
+                        s
+                    ));
+                }
+                Some(s.to_string())
+            }
+            None => None,
+        };
+
+        Ok(Self {
+            min: min.to_string(),
+            max,
+        })
+    }
+}
+
+/// Extension schema version requirements (`requires` field).
+///
+/// Declares minimum (and optionally maximum) protocol and capability
+/// versions needed for correct operation.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Requires {
+    pub protocol: Option<VersionConstraint>,
+    pub capabilities: Vec<(String, VersionConstraint)>,
+}
+
+impl Requires {
+    /// Parse from a JSON value: the top-level `requires` object.
+    pub fn parse(value: &Value) -> Result<Self, Vec<String>> {
+        let obj = value
+            .as_object()
+            .ok_or_else(|| vec!["\"requires\" must be an object".to_string()])?;
+        let mut errors = Vec::new();
+
+        let protocol = match obj.get("protocol") {
+            Some(v) => match VersionConstraint::parse(v) {
+                Ok(vc) => Some(vc),
+                Err(e) => {
+                    errors.push(format!("requires.protocol: {}", e));
+                    None
+                }
+            },
+            None => None,
+        };
+
+        let mut capabilities = Vec::new();
+        if let Some(caps_val) = obj.get("capabilities") {
+            match caps_val.as_object() {
+                Some(caps) => {
+                    for (key, val) in caps {
+                        match VersionConstraint::parse(val) {
+                            Ok(vc) => capabilities.push((key.clone(), vc)),
+                            Err(e) => errors.push(format!("requires.capabilities.{}: {}", key, e)),
+                        }
+                    }
+                }
+                None => errors.push("requires.capabilities must be an object".to_string()),
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(Self {
+                protocol,
+                capabilities,
+            })
+        } else {
+            Err(errors)
+        }
+    }
+}
+
 /// Options for schema resolution.
 #[derive(Debug, Clone)]
 pub struct ResolveOptions {
@@ -173,6 +312,121 @@ mod tests {
         // Disbarred: invalid visibility value
         assert!(!super::is_valid_schema_transition("readonly", "omit"));
         assert!(!super::is_valid_schema_transition("required", "invalid"));
+    }
+
+    #[test]
+    fn is_valid_version_format() {
+        assert!(is_valid_version("2026-01-23"));
+        assert!(is_valid_version("2025-12-31"));
+        assert!(!is_valid_version("2026-1-23"));
+        assert!(!is_valid_version("not-a-date"));
+        assert!(!is_valid_version("20260123"));
+        assert!(!is_valid_version(""));
+        // Reject nonsense dates
+        assert!(!is_valid_version("2026-13-32"));
+        assert!(!is_valid_version("2026-00-15"));
+        assert!(!is_valid_version("2026-06-00"));
+        assert!(!is_valid_version("9999-99-99"));
+    }
+
+    #[test]
+    fn version_constraint_satisfied_by() {
+        let min_only = VersionConstraint {
+            min: "2026-01-23".into(),
+            max: None,
+        };
+        assert!(!min_only.satisfied_by("2026-01-22"));
+        assert!(min_only.satisfied_by("2026-01-23")); // inclusive
+        assert!(min_only.satisfied_by("2026-06-01"));
+        assert!(min_only.satisfied_by("2099-12-31"));
+
+        let range = VersionConstraint {
+            min: "2026-01-23".into(),
+            max: Some("2026-09-01".into()),
+        };
+        assert!(!range.satisfied_by("2026-01-22"));
+        assert!(range.satisfied_by("2026-01-23")); // min inclusive
+        assert!(range.satisfied_by("2026-06-01"));
+        assert!(range.satisfied_by("2026-09-01")); // max inclusive
+        assert!(!range.satisfied_by("2026-09-02"));
+
+        // Exact pin: min == max
+        let exact = VersionConstraint {
+            min: "2026-06-01".into(),
+            max: Some("2026-06-01".into()),
+        };
+        assert!(!exact.satisfied_by("2026-05-31"));
+        assert!(exact.satisfied_by("2026-06-01"));
+        assert!(!exact.satisfied_by("2026-06-02"));
+    }
+
+    #[test]
+    fn version_constraint_parse_valid() {
+        use serde_json::json;
+        let vc = VersionConstraint::parse(&json!({"min": "2026-01-23"})).unwrap();
+        assert_eq!(vc.min, "2026-01-23");
+        assert_eq!(vc.max, None);
+
+        let vc =
+            VersionConstraint::parse(&json!({"min": "2026-01-23", "max": "2026-09-01"})).unwrap();
+        assert_eq!(vc.min, "2026-01-23");
+        assert_eq!(vc.max, Some("2026-09-01".into()));
+    }
+
+    #[test]
+    fn version_constraint_parse_invalid() {
+        use serde_json::json;
+        assert!(VersionConstraint::parse(&json!({"max": "2026-01-23"})).is_err()); // missing min
+        assert!(VersionConstraint::parse(&json!({"min": "bad"})).is_err()); // bad format
+        assert!(VersionConstraint::parse(&json!("string")).is_err()); // not object
+    }
+
+    #[test]
+    fn requires_parse_valid() {
+        use serde_json::json;
+        let req = Requires::parse(&json!({
+            "protocol": { "min": "2026-01-23" },
+            "capabilities": {
+                "dev.ucp.shopping.checkout": { "min": "2026-06-01" }
+            }
+        }))
+        .unwrap();
+        assert!(req.protocol.is_some());
+        assert_eq!(req.capabilities.len(), 1);
+        assert_eq!(req.capabilities[0].0, "dev.ucp.shopping.checkout");
+    }
+
+    #[test]
+    fn requires_parse_protocol_only() {
+        use serde_json::json;
+        let req = Requires::parse(&json!({
+            "protocol": { "min": "2026-01-23" }
+        }))
+        .unwrap();
+        assert!(req.protocol.is_some());
+        assert!(req.capabilities.is_empty());
+    }
+
+    #[test]
+    fn requires_parse_empty_object() {
+        use serde_json::json;
+        let req = Requires::parse(&json!({})).unwrap();
+        assert!(req.protocol.is_none());
+        assert!(req.capabilities.is_empty());
+    }
+
+    #[test]
+    fn requires_parse_invalid() {
+        use serde_json::json;
+        // Not an object
+        assert!(Requires::parse(&json!("string")).is_err());
+        // Bad protocol constraint
+        assert!(Requires::parse(&json!({"protocol": {"min": "bad"}})).is_err());
+        // Bad capability constraint
+        assert!(Requires::parse(&json!({
+            "capabilities": { "x.y.z": "not-object" }
+        }))
+        .is_err());
     }
 
     #[test]


### PR DESCRIPTION
UCP extension schemas need to declare which protocol and capability versions they depend on. Without this, a 3P extension (e.g., `com.acme.loyalty`) can be silently composed with a checkout version whose contract has changed — structural schema validation (`allOf`) catches missing fields but not semantic changes. [Spec PR #200](https://github.com/Universal-Commerce-Protocol/ucp/pull/200) defines a `requires` field on extension schemas to address this. 

This PR adds tooling / validation support. An extension schema declares its version dependencies:

```json
{
  "$id": "https://acme.com/ucp/schemas/loyalty.json",
  "name": "com.acme.shopping.loyalty",
  "requires": {
    "protocol": { "min": "2026-01-23" },
    "capabilities": {
      "dev.ucp.shopping.checkout": { "min": "2026-06-01", "max": "2026-09-01" }
    }
  },
  "$defs": {
    "dev.ucp.shopping.checkout": {
      "allOf": [
        { "$ref": "checkout.json" },
        { "type": "object", "properties": { "loyalty_points": { "type": "integer" } } }
      ]
    }
  }
}
```

### Lint catches authoring errors

```bash
$ ucp-schema lint loyalty.json
loyalty.json
  E006 /requires/protocol/min  invalid version format "not-a-date": expected YYYY-MM-DD
  E007 /requires/capabilities/dev.ucp.shopping.cart  requires.capabilities key "dev.ucp.shopping.cart" not found in $defs
  W004 /requires/protocol  version constraint has min (2026-09-01) > max (2026-01-23)
  W005 /requires/protocl  unknown key "protocl" in requires: expected protocol, capabilities
```

### Compose validates constraints

Given the loyalty extension above (`requires checkout >= 2026-06-01`), composing against a profile that declares `checkout: 2026-03-01` fails:
```
extension 'com.acme.loyalty' requires dev.ucp.shopping.checkout >= 2026-06-01 but found 2026-03-01
```

With a range constraint (`min: 2026-06-01, max: 2026-09-01`) and checkout at `2026-12-01`:
```
extension 'com.acme.loyalty' requires dev.ucp.shopping.checkout [2026-06-01, 2026-09-01] but found 2026-12-01
```

### Schemas without `requires` are unaffected
**Backwards compatible.** Schemas without `requires` compose as before — profile author asserts compatibility.

---

## Checklist
- [x] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [X] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.


## Related Issues
Enforces https://github.com/Universal-Commerce-Protocol/ucp/pull/200