### PR TITLE
feat: container validation for multi-message schemas

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -127,6 +127,28 @@ The validator:
 2. Extracts `$defs[root_name]` from each extension
 3. Composes them with `allOf`
 
+If the capability is a **container** (see below), repeat the base's operation keys instead: `$defs[root_name]` is itself `{ "$defs": { "<op>_<direction>": ... } }`, and the tool merges one shape at a time.
+
+---
+
+## How do I validate a catalog (or other container) capability?
+
+When a capability's request and response are different objects (a search request is a query; its response, a list of products), one file holds each shape under `$defs`, named `{op}_{direction}`. Validate by naming the operation and direction:
+
+```bash
+ucp-schema validate search-response.json --op search --response --schema-local-base ./schemas
+```
+
+The operation, not just direction, selects the shape — `catalog.lookup` holds both `lookup` and `get_product`. A missing shape errors, never passes.
+
+For shapes that aren't an operation+direction (a transport's `error_response`, a profile's `business_schema`, `cart` → `checkout`), name the `$def` with `--def`:
+
+```bash
+ucp-schema validate envelope.json --schema transports/jsonrpc.json --op read --def error_response
+```
+
+See [Container Capabilities](./README.md#container-capabilities) for the full picture.
+
 ---
 
 ## Can extensions remove required fields from the base schema?

--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ For example, a field annotated with `"ucp_request": {"create": "omit", "update":
 
 **"I want to..."**
 
-| Goal                                                | Command                                                         |
-| --------------------------------------------------- | --------------------------------------------------------------- |
-| Inspect the composed schema (annotations preserved) | `compose payload.json --schema-local-base ./schemas --pretty`   |
-| Get JSON Schema for an operation                    | `resolve payload.json --op read --schema-local-base ./schemas`  |
-| Resolve a single schema file (no composition)       | `resolve schema.json --request --op create`                     |
-| Validate a payload end-to-end                       | `validate payload.json --op read --schema-local-base ./schemas` |
-| Check schemas for errors before runtime             | `lint schemas/`                                                 |
-| Debug what the pipeline is doing                    | Add `--verbose` to any command                                  |
+| Goal                                                | Command                                                                       |
+| --------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Inspect the composed schema (annotations preserved) | `compose payload.json --schema-local-base ./schemas --pretty`                 |
+| Get JSON Schema for an operation                    | `resolve payload.json --op read --schema-local-base ./schemas`                |
+| Resolve a single schema file (no composition)       | `resolve schema.json --request --op create`                                   |
+| Validate a payload end-to-end                       | `validate payload.json --op read --schema-local-base ./schemas`               |
+| Validate a catalog (container) response             | `validate response.json --op search --response --schema-local-base ./schemas` |
+| Validate against a named shape (request/error/view) | `validate payload.json --schema s.json --op read --def error_response`        |
+| Check schemas for errors before runtime             | `lint schemas/`                                                               |
+| Debug what the pipeline is doing                    | Add `--verbose` to any command                                                |
 
 ## Installation
 
@@ -83,7 +85,11 @@ ucp-schema resolve <payload> --op <operation> --schema-local-base <dir> [options
 
 Options:
   --request / --response      Direction (required for schema input, auto-inferred for payloads)
-  --op <operation>            Operation: create, read, update, complete
+  --op <operation>            Operation; drives annotation visibility and, for
+                              container capabilities, the {op}_{direction} shape
+                              (create/read/update/complete; search/lookup/get_product)
+  --def <name>                Output a single $defs entry instead of the full
+                              schema (container capabilities; see Concepts)
   --pretty                    Pretty-print JSON output
   --output <path>             Write to file instead of stdout
   --bundle                    Inline external $ref pointers (schema input only; payloads bundle automatically)
@@ -124,7 +130,11 @@ Options:
   --schema <path|url>          Explicit schema (skips self-describing detection)
   --profile <path|url>         Agent profile (REST request pattern)
   --request / --response       Direction (required with --schema, auto-detected otherwise)
-  --op <operation>             Operation: create, read, update, complete
+  --op <operation>             Operation; drives annotation visibility and, for
+                               container capabilities, the {op}_{direction} shape
+                               (create/read/update/complete; search/lookup/get_product)
+  --def <name>                 Validate against an explicit $defs entry, overriding
+                               {op}_{direction} (see Concepts > Container Capabilities)
   --schema-local-base <dir>    Local directory to resolve schema URLs
   --schema-remote-base <url>   URL prefix to strip when mapping to local
   --strict                     Reject unknown fields (see Concepts > Strict Mode)
@@ -422,6 +432,66 @@ Extension schemas can declare which protocol and capability versions they depend
 ```
 
 Each constraint is an object with a required `min` and optional `max` (both inclusive). Keys in `requires.capabilities` must be a subset of `$defs` keys. Schemas without `requires` compose as before — the composer asserts compatibility.
+
+### Container Capabilities
+
+Typically a capability's request and response are the **same object** — you send a checkout, you get a checkout back. Fields differ by direction and operation (clients omit server-set fields), but it's one shape, handled by [visibility annotations](#visibility-rules). `checkout.json` is that object; validate against it directly.
+
+Sometimes they're **different objects**: a search request is a query, a search response is a list of products — too different for one annotated object to cover both. Then a single file carries each shape under `$defs`, named `{op}_{direction}`:
+
+```json
+{
+  "name": "dev.ucp.shopping.catalog.search",
+  "type": "object",
+  "$defs": {
+    "search_request": {},
+    "search_response": {}
+  }
+}
+```
+
+Such a schema is a **container**: the root is just a namespace of shapes. A file can hold more than two — `catalog_lookup.json` has a request and response for both `lookup` and `get_product`. (Detected structurally: `$defs` but no root body — no `properties`, `allOf`, or `$ref`.)
+
+**Picking the shape.** Validating a container means choosing which `$def` to match — two ways:
+
+- **By operation + direction (default).** `--op search --response` picks `search_response`. The operation matters, not just direction — `catalog.lookup` holds both `lookup` and `get_product`. A missing shape errors, never passes.
+- **By name (`--def`).** Name the `$def` directly, for shapes that aren't an operation+direction: a transport's `error_response`, a profile's `business_schema`, or a sub-object (`--def checkout` on a cart). Works on any schema; overrides the default.
+
+`validate` always picks one shape; `resolve` returns the whole schema unless given `--def`.
+
+```bash
+# Default: shape derived from operation + direction
+ucp-schema validate search-response.json --op search --response --schema-local-base ./schemas
+
+# By name: a shape that isn't an operation/direction
+ucp-schema validate envelope.json --schema transports/jsonrpc.json --op read --def error_response
+```
+
+**Extending a container.** A normal extension adds fields to one object; a container extension adds them _per shape_. Under `$defs[<capability>]`, repeat the `{op}_{direction}` keys and `allOf` each onto the base — the tool merges per shape, so `search_response` becomes `allOf[base, extension]`.
+
+```json
+{
+  "$id": "https://ucp.dev/schemas/shopping/fulfillment.json",
+  "name": "dev.ucp.shopping.fulfillment",
+  "$defs": {
+    "dev.ucp.shopping.catalog.search": {
+      "$defs": {
+        "search_response": {
+          "allOf": [
+            { "$ref": "catalog_search.json#/$defs/search_response" },
+            {
+              "type": "object",
+              "properties": {
+                "products": { "items": { "$ref": "#/$defs/ful_product" } }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
 
 ### Validation Modes
 

--- a/src/bin/ucp-schema.rs
+++ b/src/bin/ucp-schema.rs
@@ -9,9 +9,9 @@ use clap::{Parser, Subcommand};
 use ucp_schema::{
     bundle_refs, bundle_refs_with_url_mapping, compose_from_payload, compose_schema,
     detect_direction, extract_capabilities, extract_capabilities_from_profile,
-    extract_jsonrpc_payload, is_url, lint, load_schema, load_schema_auto, resolve, validate,
-    ComposeError, DetectedDirection, Direction, FileStatus, ResolveError, ResolveOptions,
-    SchemaBaseConfig, ValidateError,
+    extract_jsonrpc_payload, is_url, lint, load_schema, load_schema_auto, resolve,
+    select_operation_schema, validate, ComposeError, DetectedDirection, Direction, FileStatus,
+    ResolveError, ResolveOptions, SchemaBaseConfig, ValidateError,
 };
 
 /// Errors with associated CLI exit codes.
@@ -100,6 +100,12 @@ enum Commands {
         #[arg(long, short)]
         op: String,
 
+        /// Select an explicit $defs entry to output (e.g. search_response,
+        /// business_schema, error_response), overriding the {op}_{direction}
+        /// derivation for container-shaped schemas.
+        #[arg(long)]
+        def: Option<String>,
+
         /// Output file (stdout if not specified)
         #[arg(long)]
         output: Option<PathBuf>,
@@ -168,6 +174,12 @@ enum Commands {
         #[arg(long, short)]
         op: String,
 
+        /// Validate against an explicit $defs entry (e.g. search_response,
+        /// business_schema, error_response), overriding the {op}_{direction}
+        /// derivation. Works on any schema that defines the named $def.
+        #[arg(long)]
+        def: Option<String>,
+
         /// Output results as JSON (for automation)
         #[arg(long)]
         json: bool,
@@ -235,6 +247,7 @@ fn main() -> ExitCode {
             request,
             response,
             op,
+            def,
             output,
             pretty,
             bundle,
@@ -248,6 +261,7 @@ fn main() -> ExitCode {
             request,
             response,
             op,
+            def,
             output,
             pretty,
             bundle,
@@ -283,6 +297,7 @@ fn main() -> ExitCode {
             request,
             response,
             op,
+            def,
             json,
             strict,
             verbose,
@@ -295,6 +310,7 @@ fn main() -> ExitCode {
             request,
             response,
             op,
+            def,
             json_output: json,
             strict,
             verbose,
@@ -325,6 +341,7 @@ fn run_resolve(
     request: bool,
     response: bool,
     op: String,
+    def: Option<String>,
     output: Option<PathBuf>,
     pretty: bool,
     bundle: bool,
@@ -398,7 +415,8 @@ fn run_resolve(
 
     let options = ResolveOptions::new(direction, &op)
         .strict(strict)
-        .include_future(include_future);
+        .include_future(include_future)
+        .def_name(def);
     if verbose {
         let mut flags = Vec::new();
         if strict {
@@ -424,7 +442,16 @@ fn run_resolve(
     }
     let resolved = resolve(&schema, &options).map_err(cli_err(false))?;
 
-    write_json_output(&resolved, output, pretty)
+    // `resolve` defaults to emitting the full resolved schema (container $defs
+    // intact). Only an explicit --def slices to a single $def; auto-derivation
+    // is a validate-time concern, so standalone `resolve` never auto-selects.
+    let output_value = if options.def_name.is_some() {
+        select_operation_schema(&resolved, &options).map_err(cli_err(false))?
+    } else {
+        resolved
+    };
+
+    write_json_output(&output_value, output, pretty)
 }
 
 /// Pure composition: merge capability schemas from a self-describing payload.
@@ -470,6 +497,7 @@ struct ValidateArgs {
     request: bool,
     response: bool,
     op: String,
+    def: Option<String>,
     json_output: bool,
     strict: bool,
     verbose: bool,
@@ -485,6 +513,7 @@ fn run_validate(args: ValidateArgs) -> Result<(), u8> {
         request,
         response,
         op,
+        def,
         json_output,
         strict,
         verbose,
@@ -632,7 +661,9 @@ fn run_validate(args: ValidateArgs) -> Result<(), u8> {
         }
     };
 
-    let options = ResolveOptions::new(direction, op).strict(strict);
+    let options = ResolveOptions::new(direction, op)
+        .strict(strict)
+        .def_name(def);
     if verbose {
         eprintln!(
             "[resolve] resolving for {}/{}",

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -459,7 +459,10 @@ pub fn compose_schema(
         .filter(|c| c.extends.is_some())
         .collect();
 
-    // If no extensions, just return the root schema
+    // No extensions: the capability schema stands alone. For a single-object
+    // capability this root is the message body; for a container it is the
+    // namespace of `{op}_{direction}` shapes. The operation shape, if any, is
+    // chosen downstream by `select_operation_schema`.
     if extensions.is_empty() {
         return resolve_schema_url(&root.schema_url, schema_base).map_err(|e| {
             ComposeError::SchemaFetch {
@@ -469,8 +472,19 @@ pub fn compose_schema(
         });
     }
 
-    // Compose: for each extension, extract $defs[root.name]
-    let mut all_of_schemas = Vec::new();
+    // Load the root schema to classify the capability (single-object vs
+    // container) and, for a container, to seed the per-operation merge with the
+    // base's `$defs`.
+    let root_schema = resolve_schema_url(&root.schema_url, schema_base).map_err(|e| {
+        ComposeError::SchemaFetch {
+            url: root.schema_url.clone(),
+            message: e.to_string(),
+        }
+    })?;
+    let container = is_container_schema(&root_schema);
+
+    // Compose: for each extension, extract its self-contained `$defs[root.name]`.
+    let mut ext_defs = Vec::new();
 
     for ext in &extensions {
         let ext_schema = resolve_schema_url(&ext.schema_url, schema_base).map_err(|e| {
@@ -512,11 +526,115 @@ pub fn compose_schema(
         let mut inlined = ext_def.clone();
         inline_internal_refs(&mut inlined, defs);
 
-        all_of_schemas.push(inlined);
+        ext_defs.push(inlined);
     }
 
-    // Compose into single schema with allOf
-    Ok(json!({ "allOf": all_of_schemas }))
+    // Composition follows the same single-object vs container split: a
+    // single-object body is extended once at the root; a container is extended
+    // per operation shape. Both use `allOf`, and in both the base is included
+    // because each extension re-`$ref`s it.
+    if container {
+        compose_container(&root_schema, &extensions, &ext_defs, &root.name)
+    } else {
+        Ok(json!({ "allOf": ext_defs }))
+    }
+}
+
+/// Returns true if a capability schema is "container-shaped".
+///
+/// A UCP capability schema takes one of two structural forms, and the whole
+/// compose/select pipeline branches on this distinction:
+///
+/// - **Single-object** (e.g. checkout, cart): the schema root *is* the message
+///   body. A single object serves every operation and direction; the per-op /
+///   per-direction differences are expressed with visibility annotations on
+///   that one object. The validation target is the root itself.
+/// - **Container** (e.g. catalog.search, catalog.lookup): the schema is a
+///   namespace of several distinct message bodies, each held under `$defs` and
+///   keyed `{op}_{direction}` (e.g. `search_request`, `get_product_response`).
+///   The root carries no body of its own; the body for a given operation and
+///   direction is the corresponding `$defs` entry, chosen at compose/validate
+///   time (see [`compose_container`] and `select_operation_schema`).
+///
+/// Detected structurally: a container has `$defs` but no object body at the
+/// root (no `properties`, `allOf`, or `$ref`).
+pub fn is_container_schema(schema: &Value) -> bool {
+    match schema.as_object() {
+        Some(obj) => {
+            obj.contains_key("$defs")
+                && !obj.contains_key("properties")
+                && !obj.contains_key("allOf")
+                && !obj.contains_key("$ref")
+        }
+        None => false,
+    }
+}
+
+/// Compose a container-shaped capability with its extensions, merging per
+/// operation shape.
+///
+/// The result is a container with the same `$defs/{op}_{direction}` keys as the
+/// base; for any operation an extension touches, the shape becomes an `allOf` of
+/// the extension contributions (each of which re-`$ref`s the base shape, so base
+/// constraints are preserved). Base helper defs (e.g. `lookup_variant`) and
+/// operation shapes no extension touches are carried through unchanged.
+fn compose_container(
+    root_schema: &Value,
+    extensions: &[&Capability],
+    ext_defs: &[Value],
+    capability: &str,
+) -> Result<Value, ComposeError> {
+    // Seed with the base container's $defs (operation shapes + helper defs).
+    let mut merged_defs: serde_json::Map<String, Value> = root_schema
+        .get("$defs")
+        .and_then(|d| d.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    // Collect per-operation contributions in first-seen order (deterministic).
+    let mut order: Vec<String> = Vec::new();
+    let mut per_op: HashMap<String, Vec<Value>> = HashMap::new();
+
+    for (ext, inlined) in extensions.iter().zip(ext_defs.iter()) {
+        // A container extension's $defs[<capability>] must itself be a container:
+        // { "$defs": { "<op>_<direction>": <shape>, ... } } mirroring the base.
+        let nested = inlined
+            .get("$defs")
+            .and_then(|d| d.as_object())
+            .ok_or_else(|| ComposeError::ContainerExtensionShape {
+                extension: ext.name.clone(),
+                capability: capability.to_string(),
+            })?;
+
+        for (op_key, shape) in nested {
+            if !per_op.contains_key(op_key) {
+                order.push(op_key.clone());
+            }
+            per_op
+                .entry(op_key.clone())
+                .or_default()
+                .push(shape.clone());
+        }
+    }
+
+    // Fold contributions into the base $defs (overwriting the base op shape; the
+    // extension re-`$ref`s the base, so its constraints come through the allOf).
+    for op_key in order {
+        let contribs = per_op.remove(&op_key).unwrap();
+        let merged = if contribs.len() == 1 {
+            contribs.into_iter().next().unwrap()
+        } else {
+            json!({ "allOf": contribs })
+        };
+        merged_defs.insert(op_key, merged);
+    }
+
+    let mut result = root_schema.clone();
+    result
+        .as_object_mut()
+        .expect("container root is an object")
+        .insert("$defs".to_string(), Value::Object(merged_defs));
+    Ok(result)
 }
 
 /// Inline internal `#/$defs/...` refs from the parent schema.

--- a/src/error.rs
+++ b/src/error.rs
@@ -153,6 +153,13 @@ pub enum ResolveError {
     )]
     OperationShapeNotFound { key: String, available: String },
 
+    /// An explicit `--def` / `def_name` selector names a `$defs` entry that the
+    /// resolved schema does not contain. Used for non-derivable shapes (transport
+    /// message types, host views, sub-types) where the name is authored, not
+    /// computed from `(op, direction)`.
+    #[error("schema has no $defs entry '{def}'; available: [{available}]")]
+    DefNotFound { def: String, available: String },
+
     #[error("failed to bundle schema: {message}")]
     BundleError { message: String },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,19 @@ pub enum ComposeError {
         expected_key: String,
     },
 
+    /// A container-shaped capability (request/response shapes live under
+    /// `$defs/{op}_{direction}`) is extended by a schema whose `$defs[<capability>]`
+    /// is not itself a container of operation shapes. Container extensions MUST
+    /// mirror the base's operation keys (e.g. `{ "$defs": { "search_response": ... } }`).
+    #[error(
+        "extension '{extension}' does not mirror container capability '{capability}': \
+         its $defs['{capability}'] must contain a nested $defs of operation shapes"
+    )]
+    ContainerExtensionShape {
+        extension: String,
+        capability: String,
+    },
+
     #[error("failed to fetch schema from {url}: {message}")]
     SchemaFetch { url: String, message: String },
 
@@ -129,6 +142,16 @@ pub enum ResolveError {
 
     #[error("invalid schema: {message}")]
     InvalidSchema { message: String },
+
+    /// A container-shaped capability schema has no message body for the
+    /// requested `(op, direction)`. The body lives at `$defs/{op}_{direction}`;
+    /// because a container root has no body of its own, an absent key is a hard
+    /// error rather than a fall-through to an unconstrained root.
+    #[error(
+        "container schema has no operation shape '{key}' for this (op, direction); \
+         available operation shapes: [{available}]"
+    )]
+    OperationShapeNotFound { key: String, available: String },
 
     #[error("failed to bundle schema: {message}")]
     BundleError { message: String },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,8 @@ mod validator;
 pub use compose::{
     capability_short_name, check_version_constraints, compose_from_payload, compose_schema,
     detect_direction, extract_capabilities, extract_capabilities_from_profile,
-    extract_jsonrpc_payload, Capability, DetectedDirection, SchemaBaseConfig, VersionViolation,
+    extract_jsonrpc_payload, is_container_schema, Capability, DetectedDirection, SchemaBaseConfig,
+    VersionViolation,
 };
 pub use error::{ComposeError, ResolveError, SchemaError, ValidateError};
 pub use linter::{lint, lint_file, Diagnostic, FileResult, FileStatus, LintResult, Severity};
@@ -75,7 +76,7 @@ pub use loader::{
 };
 pub use resolver::{resolve, strip_annotations};
 pub use types::{Direction, Requires, ResolveOptions, VersionConstraint, Visibility};
-pub use validator::{validate, validate_against_schema};
+pub use validator::{select_operation_schema, validate, validate_against_schema};
 
 #[cfg(feature = "remote")]
 pub use loader::{bundle_refs_remote, load_schema_url};

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -597,29 +597,46 @@ mod tests {
         assert_eq!(path, Path::new("/local/schemas/foo.json"));
     }
 
-    // Remote tests - require network, use httpbin.org for reliable testing
+    // Remote tests run against a local mockito server so they're deterministic
+    // and offline — no dependency on a live third party. The connection-error
+    // case uses a reserved `.invalid` host (RFC 2606), which fails to resolve
+    // locally without touching the network.
     #[cfg(feature = "remote")]
     mod remote {
         use super::*;
 
         #[test]
         fn load_schema_url_valid() {
-            // httpbin.org/json returns a well-known JSON response
-            let result = load_schema_url("https://httpbin.org/json");
-            assert!(result.is_ok());
-            let schema = result.unwrap();
-            // httpbin returns {"slideshow": {...}}
-            assert!(schema.get("slideshow").is_some());
+            // 200 + JSON body resolves to the parsed value.
+            let mut server = mockito::Server::new();
+            let mock = server
+                .mock("GET", "/schema.json")
+                .with_header("content-type", "application/json")
+                .with_body(r#"{"type": "object"}"#)
+                .create();
+
+            let result = load_schema_url(&format!("{}/schema.json", server.url()));
+            assert_eq!(result.unwrap()["type"], "object");
+            mock.assert();
         }
 
         #[test]
         fn load_schema_url_404() {
-            let result = load_schema_url("https://httpbin.org/status/404");
+            // Non-2xx status surfaces as NetworkError (via error_for_status).
+            let mut server = mockito::Server::new();
+            server
+                .mock("GET", "/missing.json")
+                .with_status(404)
+                .create();
+
+            let result = load_schema_url(&format!("{}/missing.json", server.url()));
             assert!(matches!(result, Err(ResolveError::NetworkError { .. })));
         }
 
         #[test]
         fn load_schema_url_invalid_host() {
+            // Connection/DNS failure surfaces as NetworkError. `.invalid` (RFC
+            // 2606) fails to resolve without network access.
             let result =
                 load_schema_url("https://this-domain-does-not-exist-12345.invalid/schema.json");
             assert!(matches!(result, Err(ResolveError::NetworkError { .. })));
@@ -627,8 +644,17 @@ mod tests {
 
         #[test]
         fn load_schema_auto_url() {
-            let result = load_schema_auto("https://httpbin.org/json");
-            assert!(result.is_ok());
+            // A URL source delegates to load_schema_url.
+            let mut server = mockito::Server::new();
+            let mock = server
+                .mock("GET", "/schema.json")
+                .with_header("content-type", "application/json")
+                .with_body(r#"{"type": "string"}"#)
+                .create();
+
+            let result = load_schema_auto(&format!("{}/schema.json", server.url()));
+            assert_eq!(result.unwrap()["type"], "string");
+            mock.assert();
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -49,6 +49,18 @@ impl Direction {
         }
     }
 
+    /// Returns the bare direction string ("request" / "response").
+    ///
+    /// Used to build container operation-shape keys (`{op}_{direction}`,
+    /// e.g. `search_response`) when selecting the validation target for
+    /// container-shaped capabilities.
+    pub fn dir_str(&self) -> &'static str {
+        match self {
+            Direction::Request => "request",
+            Direction::Response => "response",
+        }
+    }
+
     /// Create direction from a request flag (true = Request, false = Response).
     pub fn from_request_flag(is_request: bool) -> Self {
         if is_request {

--- a/src/types.rs
+++ b/src/types.rs
@@ -263,6 +263,14 @@ pub struct ResolveOptions {
     /// added to `required`. Completes the lifecycle symmetry: deprecations (to=omit)
     /// are always surfaced; this flag surfaces planned additions (from=omit) too.
     pub include_future: bool,
+    /// Explicit `$defs` entry to select as the validation/output target,
+    /// overriding the `{op}_{direction}` derivation used for container
+    /// capabilities. Names non-derivable shapes that aren't an operation +
+    /// direction — transport message types (`error_response`), host views
+    /// (`business_schema`), and sub-types of single-object schemas
+    /// (`cart` → `checkout`). When set, selection ignores the container check
+    /// so it works on schemas that also have a root body.
+    pub def_name: Option<String>,
 }
 
 impl ResolveOptions {
@@ -277,6 +285,7 @@ impl ResolveOptions {
             operation: operation.into().to_lowercase(),
             strict: false,
             include_future: false,
+            def_name: None,
         }
     }
 
@@ -289,6 +298,13 @@ impl ResolveOptions {
     /// Include future fields (omit-visibility with non-omit transition target).
     pub fn include_future(mut self, include_future: bool) -> Self {
         self.include_future = include_future;
+        self
+    }
+
+    /// Select an explicit `$defs` entry, overriding `{op}_{direction}`
+    /// derivation (see [`Self::def_name`]).
+    pub fn def_name(mut self, def_name: Option<String>) -> Self {
+        self.def_name = def_name;
         self
     }
 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -34,49 +34,82 @@ pub fn validate(
 
 /// Resolve a (possibly container-shaped) schema to its validation target.
 ///
-/// For a single-object capability the target is the root, returned unchanged.
-/// For a container capability (see [`crate::is_container_schema`]) the target is
-/// the message body for this `(op, direction)`, held at `$defs/{op}_{direction}`;
-/// this roots validation there via a `$ref` while keeping the sibling `$defs`
-/// and `$schema` in scope so internal refs and the dialect still resolve.
+/// Selection has two modes:
 ///
-/// A container root carries no body of its own, so an absent `{op}_{direction}`
-/// is reported as `OperationShapeNotFound` rather than falling through to an
-/// unconstrained root.
+/// - **Explicit** (`options.def_name`): root at the named `$defs` entry,
+///   regardless of schema shape. Names non-derivable shapes — transport message
+///   types (`error_response`), host views (`business_schema`) — and sub-types of
+///   single-object schemas (`cart` → `checkout`), where the root has a body but
+///   a fragment is being validated. Absent name → `DefNotFound`.
+/// - **Derived** (no `def_name`): single-object capabilities validate at the
+///   root unchanged; for a container capability (see
+///   [`crate::is_container_schema`]) the target is the message body for this
+///   `(op, direction)`, held at `$defs/{op}_{direction}`. A container root has
+///   no body of its own, so an absent shape → `OperationShapeNotFound` rather
+///   than a fall-through to an unconstrained root.
+///
+/// Either way the chosen `$def` is rooted via a `$ref` that keeps the sibling
+/// `$defs` and `$schema` in scope, so internal refs and the dialect resolve.
 pub fn select_operation_schema(
     schema: &Value,
     options: &ResolveOptions,
 ) -> Result<Value, ResolveError> {
+    if let Some(def) = &options.def_name {
+        return select_def(schema, def, SelectMode::Explicit);
+    }
     if !is_container_schema(schema) {
         return Ok(schema.clone());
     }
-
     let key = format!("{}_{}", options.operation, options.direction.dir_str());
-    let defs = schema.get("$defs").and_then(|d| d.as_object());
+    select_def(schema, &key, SelectMode::Derived)
+}
 
-    let has_key = defs.map(|d| d.contains_key(&key)).unwrap_or(false);
-    if !has_key {
+/// Whether the selected `$def` name was authored (`--def`) or computed from
+/// `(op, direction)`. Only affects which "available" hint and error variant a
+/// miss produces.
+enum SelectMode {
+    Explicit,
+    Derived,
+}
+
+/// Root validation at `$defs/{name}` via a `$ref` wrapper that retains the
+/// sibling `$defs` and `$schema`.
+fn select_def(schema: &Value, name: &str, mode: SelectMode) -> Result<Value, ResolveError> {
+    let defs = schema.get("$defs").and_then(|d| d.as_object());
+    let present = defs.map(|d| d.contains_key(name)).unwrap_or(false);
+    if !present {
         let available = defs
-            .map(|d| {
-                d.keys()
+            .map(|d| match mode {
+                // Derived selection only ever targets operation shapes, so the
+                // hint lists those; explicit selection can name any $def.
+                SelectMode::Derived => d
+                    .keys()
                     .filter(|k| k.ends_with("_request") || k.ends_with("_response"))
                     .cloned()
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                    .collect::<Vec<_>>(),
+                SelectMode::Explicit => d.keys().cloned().collect::<Vec<_>>(),
             })
-            .unwrap_or_default();
-        return Err(ResolveError::OperationShapeNotFound { key, available });
+            .unwrap_or_default()
+            .join(", ");
+        return Err(match mode {
+            SelectMode::Derived => ResolveError::OperationShapeNotFound {
+                key: name.to_string(),
+                available,
+            },
+            SelectMode::Explicit => ResolveError::DefNotFound {
+                def: name.to_string(),
+                available,
+            },
+        });
     }
 
-    // Thin wrapper rooted at the operation shape. `$ref` + sibling `$defs` is
-    // valid JSON Schema 2020-12 and keeps every sibling def resolvable.
     let mut wrapper = Map::new();
     if let Some(s) = schema.get("$schema") {
         wrapper.insert("$schema".to_string(), s.clone());
     }
     wrapper.insert(
         "$ref".to_string(),
-        Value::String(format!("#/$defs/{}", key)),
+        Value::String(format!("#/$defs/{}", name)),
     );
     if let Some(defs) = schema.get("$defs") {
         wrapper.insert("$defs".to_string(), defs.clone());

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,30 +1,87 @@
 //! Payload validation against resolved schemas.
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 
+use crate::compose::is_container_schema;
 use crate::error::{ResolveError, SchemaError, ValidateError};
 use crate::resolver::resolve;
 use crate::types::ResolveOptions;
 
 /// Validate a payload against a UCP schema.
 ///
-/// Resolves the schema for the given direction and operation, then validates
-/// the payload against the resolved schema.
+/// Resolves the schema for the given direction and operation, selects the
+/// operation shape for container-shaped capabilities, then validates the
+/// payload against the resulting schema.
 ///
 /// # Errors
 ///
-/// Returns `ValidateError::Resolve` if schema resolution fails, or
-/// `ValidateError::Invalid` if the payload doesn't match the schema.
+/// Returns `ValidateError::Resolve` if schema resolution or operation-shape
+/// selection fails, or `ValidateError::Invalid` if the payload doesn't match.
 pub fn validate(
     schema: &Value,
     payload: &Value,
     options: &ResolveOptions,
 ) -> Result<(), ValidateError> {
-    // First resolve the schema
     let resolved = resolve(schema, options)?;
 
-    // Then validate against resolved schema
-    validate_against_schema(&resolved, payload)
+    // The message body to validate depends on the capability's shape:
+    // single-object capabilities validate at the root; container capabilities
+    // validate at the selected operation shape.
+    let target = select_operation_schema(&resolved, options)?;
+
+    validate_against_schema(&target, payload)
+}
+
+/// Resolve a (possibly container-shaped) schema to its validation target.
+///
+/// For a single-object capability the target is the root, returned unchanged.
+/// For a container capability (see [`crate::is_container_schema`]) the target is
+/// the message body for this `(op, direction)`, held at `$defs/{op}_{direction}`;
+/// this roots validation there via a `$ref` while keeping the sibling `$defs`
+/// and `$schema` in scope so internal refs and the dialect still resolve.
+///
+/// A container root carries no body of its own, so an absent `{op}_{direction}`
+/// is reported as `OperationShapeNotFound` rather than falling through to an
+/// unconstrained root.
+pub fn select_operation_schema(
+    schema: &Value,
+    options: &ResolveOptions,
+) -> Result<Value, ResolveError> {
+    if !is_container_schema(schema) {
+        return Ok(schema.clone());
+    }
+
+    let key = format!("{}_{}", options.operation, options.direction.dir_str());
+    let defs = schema.get("$defs").and_then(|d| d.as_object());
+
+    let has_key = defs.map(|d| d.contains_key(&key)).unwrap_or(false);
+    if !has_key {
+        let available = defs
+            .map(|d| {
+                d.keys()
+                    .filter(|k| k.ends_with("_request") || k.ends_with("_response"))
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .unwrap_or_default();
+        return Err(ResolveError::OperationShapeNotFound { key, available });
+    }
+
+    // Thin wrapper rooted at the operation shape. `$ref` + sibling `$defs` is
+    // valid JSON Schema 2020-12 and keeps every sibling def resolvable.
+    let mut wrapper = Map::new();
+    if let Some(s) = schema.get("$schema") {
+        wrapper.insert("$schema".to_string(), s.clone());
+    }
+    wrapper.insert(
+        "$ref".to_string(),
+        Value::String(format!("#/$defs/{}", key)),
+    );
+    if let Some(defs) = schema.get("$defs") {
+        wrapper.insert("$defs".to_string(), defs.clone());
+    }
+    Ok(Value::Object(wrapper))
 }
 
 /// Validate a payload against an already-resolved schema.

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -1,0 +1,417 @@
+//! Integration tests for container-shaped capability composition + validation.
+//!
+//! A container capability holds several message bodies under
+//! `$defs/{op}_{direction}` rather than being a single validatable object, so
+//! the body to validate is selected by operation and direction. These tests
+//! pin that contract:
+//!   1. A container validates against the selected message body (a body that
+//!      violates the shape is rejected).
+//!   2. `{op}_{direction}` selects the right body across operations (search vs
+//!      lookup vs get_product) and directions (request vs response).
+//!   3. A requested operation with no body is a hard error, not a pass.
+//!   4. An extension that mirrors the container per operation composes per
+//!      operation via allOf — base AND extension constraints both apply.
+//!   5. Single-object capabilities (checkout) are unaffected.
+//!   6. An extension that does not mirror the container is rejected.
+
+use std::path::Path;
+
+use serde_json::{json, Value};
+use ucp_schema::{
+    compose_from_payload, is_container_schema, select_operation_schema, validate, Direction,
+    ResolveOptions, SchemaBaseConfig, ValidateError,
+};
+
+/// Write the fixture schema tree under `<dir>/schemas/shopping/` and return the
+/// schema base config that maps `https://ucp.dev/schemas/...` to it.
+fn write_fixtures(dir: &Path) {
+    let shopping = dir.join("schemas/shopping");
+    std::fs::create_dir_all(&shopping).unwrap();
+
+    // Base container capability: catalog.search. No object body at root; the
+    // request/response shapes live under $defs. `search_response` references a
+    // sibling helper def (`product`) to exercise sibling-ref handling.
+    std::fs::write(
+        shopping.join("catalog_search.json"),
+        r##"{
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://ucp.dev/schemas/shopping/catalog_search.json",
+          "name": "dev.ucp.shopping.catalog.search",
+          "type": "object",
+          "$defs": {
+            "search_request": {
+              "type": "object",
+              "required": ["query"],
+              "properties": { "query": { "type": "string" } }
+            },
+            "search_response": {
+              "type": "object",
+              "required": ["products"],
+              "properties": {
+                "products": { "type": "array", "items": { "$ref": "#/$defs/product" } }
+              }
+            },
+            "product": {
+              "type": "object",
+              "required": ["id", "title"],
+              "properties": {
+                "id": { "type": "string" },
+                "title": { "type": "string" }
+              }
+            }
+          }
+        }"##,
+    )
+    .unwrap();
+
+    // Extension capability: fulfillment. Mirrors the container per operation
+    // under $defs[<capability>].$defs, re-$ref-ing the base op shape and adding
+    // fields (the fulfillment-branch shape).
+    std::fs::write(
+        shopping.join("fulfillment.json"),
+        r##"{
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://ucp.dev/schemas/shopping/fulfillment.json",
+          "name": "dev.ucp.shopping.fulfillment",
+          "$defs": {
+            "dev.ucp.shopping.catalog.search": {
+              "$defs": {
+                "search_request": { "$ref": "#/$defs/ful_search_request" },
+                "search_response": { "$ref": "#/$defs/ful_search_response" }
+              }
+            },
+            "ful_search_request": {
+              "allOf": [
+                { "$ref": "catalog_search.json#/$defs/search_request" },
+                { "type": "object", "properties": { "radius_km": { "type": "number" } } }
+              ]
+            },
+            "ful_search_response": {
+              "allOf": [
+                { "$ref": "catalog_search.json#/$defs/search_response" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "products": { "type": "array", "items": { "$ref": "#/$defs/ful_product" } }
+                  }
+                }
+              ]
+            },
+            "ful_product": {
+              "allOf": [
+                { "$ref": "catalog_search.json#/$defs/product" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "fulfillment_methods": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              ]
+            }
+          }
+        }"##,
+    )
+    .unwrap();
+
+    // Single-object capability: checkout. Root IS the validatable object.
+    std::fs::write(
+        shopping.join("checkout.json"),
+        r##"{
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://ucp.dev/schemas/shopping/checkout.json",
+          "name": "dev.ucp.shopping.checkout",
+          "type": "object",
+          "required": ["id"],
+          "properties": { "id": { "type": "string" } }
+        }"##,
+    )
+    .unwrap();
+
+    // Loyalty-style extension that does NOT mirror the container (direct allOf
+    // onto the response shape instead of a nested $defs of operation keys).
+    std::fs::write(
+        shopping.join("loyalty.json"),
+        r##"{
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://ucp.dev/schemas/shopping/loyalty.json",
+          "name": "dev.ucp.shopping.loyalty",
+          "$defs": {
+            "dev.ucp.shopping.catalog.search": {
+              "allOf": [
+                { "$ref": "catalog_search.json#/$defs/search_response" },
+                { "type": "object", "properties": { "rewards": { "type": "array" } } }
+              ]
+            }
+          }
+        }"##,
+    )
+    .unwrap();
+}
+
+fn config(dir: &Path) -> SchemaBaseConfig<'static> {
+    // Leak the base path so the borrow is 'static for test convenience.
+    let base: &'static Path = Box::leak(dir.join("schemas").into_boxed_path());
+    SchemaBaseConfig {
+        local_base: Some(base),
+        remote_base: Some("https://ucp.dev/schemas"),
+    }
+}
+
+fn search_payload(products: Value) -> Value {
+    json!({
+        "ucp": { "capabilities": {
+            "dev.ucp.shopping.catalog.search": [
+                { "version": "2026-04-08", "schema": "https://ucp.dev/schemas/shopping/catalog_search.json" }
+            ]
+        } },
+        "products": products
+    })
+}
+
+fn search_payload_with_fulfillment(products: Value) -> Value {
+    json!({
+        "ucp": { "capabilities": {
+            "dev.ucp.shopping.catalog.search": [
+                { "version": "2026-04-08", "schema": "https://ucp.dev/schemas/shopping/catalog_search.json" }
+            ],
+            "dev.ucp.shopping.fulfillment": [
+                { "version": "2026-04-08", "schema": "https://ucp.dev/schemas/shopping/fulfillment.json", "extends": "dev.ucp.shopping.catalog.search" }
+            ]
+        } },
+        "products": products
+    })
+}
+
+// --- 1. Container validates against its selected message body ---
+
+#[test]
+fn base_container_bad_response_is_invalid() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixtures(dir.path());
+    let cfg = config(dir.path());
+
+    // Product missing required `title`: must be rejected by the search_response
+    // body, not waved through against the body-less container root.
+    let payload = search_payload(json!([{ "id": "p1", "BOGUS": true }]));
+    let schema = compose_from_payload(&payload, &cfg).unwrap();
+    let opts = ResolveOptions::new(Direction::Response, "search");
+
+    let result = validate(&schema, &payload, &opts);
+    assert!(
+        matches!(result, Err(ValidateError::Invalid { .. })),
+        "bad catalog search response must be INVALID, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn base_container_good_response_is_valid() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixtures(dir.path());
+    let cfg = config(dir.path());
+
+    let payload = search_payload(json!([{ "id": "p1", "title": "Widget" }]));
+    let schema = compose_from_payload(&payload, &cfg).unwrap();
+    let opts = ResolveOptions::new(Direction::Response, "search");
+
+    assert!(validate(&schema, &payload, &opts).is_ok());
+}
+
+#[test]
+fn base_container_request_selects_request_shape() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixtures(dir.path());
+    let cfg = config(dir.path());
+
+    // A response-shaped payload validated as a REQUEST must fail: search_request
+    // requires `query`, not `products`.
+    let payload = search_payload(json!([{ "id": "p1", "title": "Widget" }]));
+    let schema = compose_from_payload(&payload, &cfg).unwrap();
+    let opts = ResolveOptions::new(Direction::Request, "search");
+
+    assert!(matches!(
+        validate(&schema, &payload, &opts),
+        Err(ValidateError::Invalid { .. })
+    ));
+}
+
+// --- 3. A requested operation with no body is a hard error ---
+
+#[test]
+fn missing_operation_shape_fails_loud() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixtures(dir.path());
+    let cfg = config(dir.path());
+
+    let payload = search_payload(json!([{ "id": "p1", "title": "Widget" }]));
+    let schema = compose_from_payload(&payload, &cfg).unwrap();
+    // `read` is not an operation of this container -> read_response doesn't exist.
+    let opts = ResolveOptions::new(Direction::Response, "read");
+
+    let result = validate(&schema, &payload, &opts);
+    match result {
+        Err(ValidateError::Resolve(e)) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("read_response") && msg.contains("search_response"),
+                "expected fail-loud naming missing + available shapes, got: {msg}"
+            );
+        }
+        other => panic!("expected loud Resolve error, got {:?}", other),
+    }
+}
+
+// --- 4. Extension composes per operation (base AND extension constraints) ---
+
+#[test]
+fn extension_good_response_is_valid() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixtures(dir.path());
+    let cfg = config(dir.path());
+
+    let payload = search_payload_with_fulfillment(json!([{
+        "id": "p1", "title": "Widget", "fulfillment_methods": ["shipping"]
+    }]));
+    let schema = compose_from_payload(&payload, &cfg).unwrap();
+    let opts = ResolveOptions::new(Direction::Response, "search");
+
+    assert!(
+        validate(&schema, &payload, &opts).is_ok(),
+        "valid fulfillment-extended response should pass"
+    );
+}
+
+#[test]
+fn extension_base_constraint_still_applies() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixtures(dir.path());
+    let cfg = config(dir.path());
+
+    // Missing `title` (BASE constraint) even though fulfillment fields are fine.
+    let payload = search_payload_with_fulfillment(json!([{
+        "id": "p1", "fulfillment_methods": ["shipping"]
+    }]));
+    let schema = compose_from_payload(&payload, &cfg).unwrap();
+    let opts = ResolveOptions::new(Direction::Response, "search");
+
+    assert!(
+        matches!(
+            validate(&schema, &payload, &opts),
+            Err(ValidateError::Invalid { .. })
+        ),
+        "base 'title' requirement must still apply under the extension"
+    );
+}
+
+#[test]
+fn extension_constraint_applies() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixtures(dir.path());
+    let cfg = config(dir.path());
+
+    // `fulfillment_methods` wrong type (EXTENSION constraint). Base fields valid.
+    let payload = search_payload_with_fulfillment(json!([{
+        "id": "p1", "title": "Widget", "fulfillment_methods": "NOT_AN_ARRAY"
+    }]));
+    let schema = compose_from_payload(&payload, &cfg).unwrap();
+    let opts = ResolveOptions::new(Direction::Response, "search");
+
+    assert!(
+        matches!(
+            validate(&schema, &payload, &opts),
+            Err(ValidateError::Invalid { .. })
+        ),
+        "extension 'fulfillment_methods' type must be enforced (proves per-op merge)"
+    );
+}
+
+// --- 5. Single-object capability is unaffected ---
+
+#[test]
+fn single_object_capability_unchanged() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixtures(dir.path());
+    let cfg = config(dir.path());
+
+    let good = json!({
+        "ucp": { "capabilities": { "dev.ucp.shopping.checkout": [
+            { "version": "2026-04-08", "schema": "https://ucp.dev/schemas/shopping/checkout.json" } ] } },
+        "id": "co_1"
+    });
+    let schema = compose_from_payload(&good, &cfg).unwrap();
+    assert!(
+        !is_container_schema(&schema),
+        "checkout root is a single object, not a container"
+    );
+    let opts = ResolveOptions::new(Direction::Response, "read");
+    assert!(validate(&schema, &good, &opts).is_ok());
+
+    // Missing required `id` -> invalid (root validation, no selection).
+    let bad = json!({
+        "ucp": { "capabilities": { "dev.ucp.shopping.checkout": [
+            { "version": "2026-04-08", "schema": "https://ucp.dev/schemas/shopping/checkout.json" } ] } }
+    });
+    assert!(matches!(
+        validate(&schema, &bad, &opts),
+        Err(ValidateError::Invalid { .. })
+    ));
+}
+
+// --- 6. Non-mirroring (loyalty-style) container extension is rejected ---
+
+#[test]
+fn non_mirroring_container_extension_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixtures(dir.path());
+    let cfg = config(dir.path());
+
+    let payload = json!({
+        "ucp": { "capabilities": {
+            "dev.ucp.shopping.catalog.search": [
+                { "version": "2026-04-08", "schema": "https://ucp.dev/schemas/shopping/catalog_search.json" } ],
+            "dev.ucp.shopping.loyalty": [
+                { "version": "2026-04-08", "schema": "https://ucp.dev/schemas/shopping/loyalty.json", "extends": "dev.ucp.shopping.catalog.search" } ]
+        } },
+        "products": []
+    });
+
+    let result = compose_from_payload(&payload, &cfg);
+    assert!(
+        result.is_err(),
+        "a container extension that doesn't mirror operation keys must be rejected, got {:?}",
+        result
+    );
+}
+
+// --- select_operation_schema unit behavior ---
+
+#[test]
+fn select_is_noop_for_single_object() {
+    let schema = json!({ "type": "object", "properties": { "id": { "type": "string" } } });
+    let opts = ResolveOptions::new(Direction::Response, "read");
+    let selected = select_operation_schema(&schema, &opts).unwrap();
+    assert_eq!(
+        selected, schema,
+        "single-object schemas pass through unchanged"
+    );
+}
+
+#[test]
+fn select_wraps_container_with_ref_and_defs() {
+    let schema = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "$defs": {
+            "search_request": { "type": "object" },
+            "search_response": { "type": "object", "required": ["products"] }
+        }
+    });
+    let opts = ResolveOptions::new(Direction::Response, "search");
+    let selected = select_operation_schema(&schema, &opts).unwrap();
+    assert_eq!(selected["$ref"], "#/$defs/search_response");
+    assert!(selected["$defs"]["search_response"].is_object());
+    assert!(
+        selected["$defs"]["search_request"].is_object(),
+        "sibling defs retained"
+    );
+}

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -127,6 +127,28 @@ fn write_fixtures(dir: &Path) {
     )
     .unwrap();
 
+    // Single-object capability with a sub-type under $defs (cart holds a
+    // `checkout` def). Exercises explicit --def on a schema that HAS a root body.
+    std::fs::write(
+        shopping.join("cart.json"),
+        r##"{
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://ucp.dev/schemas/shopping/cart.json",
+          "name": "dev.ucp.shopping.cart",
+          "type": "object",
+          "required": ["id"],
+          "properties": { "id": { "type": "string" } },
+          "$defs": {
+            "checkout": {
+              "type": "object",
+              "required": ["token"],
+              "properties": { "token": { "type": "string" } }
+            }
+          }
+        }"##,
+    )
+    .unwrap();
+
     // Loyalty-style extension that does NOT mirror the container (direct allOf
     // onto the response shape instead of a nested $defs of operation keys).
     std::fs::write(
@@ -414,4 +436,76 @@ fn select_wraps_container_with_ref_and_defs() {
         selected["$defs"]["search_request"].is_object(),
         "sibling defs retained"
     );
+}
+
+// --- explicit --def selection (the Job B / named-shape escape hatch) ---
+
+#[test]
+fn explicit_def_selects_subtype_on_schema_with_body() {
+    // cart has a root body AND a `checkout` sub-type. --def must select the
+    // sub-type, not fall through to the (container-check-failing) root.
+    let schema = json!({
+        "type": "object",
+        "required": ["id"],
+        "properties": { "id": { "type": "string" } },
+        "$defs": { "checkout": { "type": "object", "required": ["token"] } }
+    });
+    let opts =
+        ResolveOptions::new(Direction::Request, "create").def_name(Some("checkout".to_string()));
+    let selected = select_operation_schema(&schema, &opts).unwrap();
+    assert_eq!(selected["$ref"], "#/$defs/checkout");
+}
+
+#[test]
+fn explicit_def_overrides_derivation() {
+    // op/direction would derive search_response; --def search_request wins.
+    let schema = json!({
+        "type": "object",
+        "$defs": {
+            "search_request": { "type": "object", "required": ["query"] },
+            "search_response": { "type": "object", "required": ["products"] }
+        }
+    });
+    let opts = ResolveOptions::new(Direction::Response, "search")
+        .def_name(Some("search_request".to_string()));
+    let selected = select_operation_schema(&schema, &opts).unwrap();
+    assert_eq!(selected["$ref"], "#/$defs/search_request");
+}
+
+#[test]
+fn explicit_def_missing_is_loud() {
+    let schema = json!({ "type": "object", "$defs": { "a": {}, "b": {} } });
+    let opts = ResolveOptions::new(Direction::Request, "create").def_name(Some("nope".to_string()));
+    let err = select_operation_schema(&schema, &opts).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("nope") && msg.contains('a') && msg.contains('b'),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn explicit_def_validates_fragment_end_to_end() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixtures(dir.path());
+    let cfg = config(dir.path());
+
+    let payload = json!({
+        "ucp": { "capabilities": { "dev.ucp.shopping.cart": [
+            { "version": "2026-04-08", "schema": "https://ucp.dev/schemas/shopping/cart.json" } ] } },
+        "token": "ok"
+    });
+    let schema = compose_from_payload(&payload, &cfg).unwrap();
+
+    // Against the cart root, `token` alone is invalid (id required). Against
+    // --def checkout, the same fragment is valid (token required).
+    let root_opts = ResolveOptions::new(Direction::Request, "create");
+    assert!(matches!(
+        validate(&schema, &payload, &root_opts),
+        Err(ValidateError::Invalid { .. })
+    ));
+
+    let def_opts =
+        ResolveOptions::new(Direction::Request, "create").def_name(Some("checkout".to_string()));
+    assert!(validate(&schema, &payload, &def_opts).is_ok());
 }


### PR DESCRIPTION
`ucp-schema validate` silently passed **any** payload for a whole class of capabilities (`catalog.search`, `catalog.lookup`). This PR teaches compose and validate that a capability schema can carry **more than one message shape**, and selects the right one by operation + direction — with an explicit `--def` override for shapes that aren't an operation. Single-object capabilities (checkout, cart, order) are unchanged.

## The problem

Most capability schemas describe **one object** — a checkout request and a checkout response are the same shape, and visibility annotations handle the per-direction differences. But some capabilities have a request and response that are **genuinely different objects**: a search request is a query, a search response is a list of products. Those schemas put each shape under `$defs`:

```json
// catalog_search.json — root has no fields of its own
{ "name": "dev.ucp.shopping.catalog.search", "type": "object",
  "$defs": { "search_request": {}, "search_response": {} } }
```

`compose` returned that body-less root and `validate` checked payloads against it. With no `properties` and `additionalProperties` defaulting open, the root accepts literally anything:

```console
$ ucp-schema validate --response --op search bad_search.json   # product missing every required field
Valid          # ❌ should be INVALID
```

This affected every `catalog.*` request/response in the standalone CLI. (Doc examples were safe only because the spec harness pre-selects the `$def` itself.)

## What changed

**1. Compose understands containers.** A schema with `$defs` but no root body (no `properties`/`allOf`/`$ref`) is a *container*. Extensions onto a container mirror its operation keys and merge **per shape** instead of once at the root — the existing `allOf` strategy applied per `{op}_{direction}`.

**2. Validate selects the shape.** Two ways:

- **Derived (default)** — `{op}_{direction}` picks the `$def`. The operation matters, not just direction: `catalog.lookup` holds both `lookup` and `get_product`, which share a direction.

  ```console
  $ ucp-schema validate --response --op search bad_search.json
  Validation failed:
    /products/0: "title" is a required property
    /products/0: "price_range" is a required property      # ✅ now enforced
  ```

- **Explicit (`--def <name>`)** — names the `$def` directly, for shapes that *aren't* an operation+direction: a transport's `error_response`, a profile's `business_schema`, or a sub-object like `--def checkout` on a cart. Works on any schema (even one with a root body) and overrides the derivation.

  ```console
  $ ucp-schema validate --schema transports/jsonrpc.json --op read --def error_response env.json
  ```

**3. Fail loud.** A container root constrains nothing, so a missing shape is a hard error instead of a vacuous pass:

```console
$ ucp-schema validate --response --op read search.json
Error: container schema has no operation shape 'read_response'; available: [search_request, search_response]
```

----

## Checklist

- [x] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
