### PR TITLE
feat: enforce namespace authority binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,6 +1762,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "2"
 clap = { version = "4", features = ["derive"] }
 jsonschema = "0.26"
+url = "2"
 
 [dependencies.reqwest]
 version = "0.12"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Options:
 
 `compose` does not accept `--request`/`--response`/`--op` — those belong to `resolve` and `validate`.
 
+**Namespace authority binding.** Before any schema is fetched, `compose` (and
+`validate`/`resolve` when composing from a payload) verifies that each
+capability's `schema` URL origin matches the reverse-domain authority in its
+name — e.g. `dev.ucp.*` schemas MUST be served from `ucp.dev`. A capability that
+fails this binding is rejected (exit `2`) without dereferencing the URL. Schema
+values that are not `http(s)` URLs (local paths) have no origin and are skipped.
+This enforcement is unconditional; see the spec's Authority Binding section for
+the rule.
+
 ```bash
 # Inspect the merged schema before resolution
 ucp-schema compose response.json --schema-local-base ./schemas --pretty
@@ -188,6 +197,7 @@ Options:
 | E005 | Annotations | Invalid `ucp_*` type (must be string or object)                | Error    |
 | E006 | Requires    | Invalid `requires` structure (wrong types, bad version format) | Error    |
 | E007 | Requires    | `requires.capabilities` key not found in `$defs`               | Error    |
+| E008 | Examples    | An `examples` entry does not validate against its own schema   | Error    |
 | W002 | Hygiene     | Missing `$id` field                                            | Warning  |
 | W003 | Hygiene     | Unknown operation in annotation (e.g., `{"delete": "omit"}`)   | Warning  |
 | W004 | Requires    | Version constraint has `min` > `max`                           | Warning  |

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -409,6 +409,22 @@ pub fn compose_schema(
         return Err(ComposeError::EmptyCapabilities);
     }
 
+    // Authority binding: a capability's `schema` URL must originate from the
+    // namespace authority encoded in its name (spec §Authority Binding). Verify
+    // ALL capabilities before dereferencing any of them (validate-before-fetch).
+    // This is unconditional — the spec requires it and there is no opt-out;
+    // non-URL schema values (local paths) carry no origin, so they are skipped.
+    for cap in capabilities {
+        if is_url(&cap.schema_url) {
+            if let Err(e) = crate::namespace::validate_binding(&cap.name, &cap.schema_url) {
+                return Err(ComposeError::NamespaceBindingViolation {
+                    capability: cap.name.clone(),
+                    message: e.to_string(),
+                });
+            }
+        }
+    }
+
     // Build name -> capability map for lookups
     let cap_map: HashMap<&str, &Capability> =
         capabilities.iter().map(|c| (c.name.as_str(), c)).collect();
@@ -1045,6 +1061,59 @@ mod tests {
         };
         let result = compose_schema(&[checkout], &config);
         assert!(matches!(result, Err(ComposeError::SchemaFetch { .. })));
+    }
+
+    #[test]
+    fn compose_rejects_unbound_schema_url() {
+        // dev.ucp.* served from a non-ucp.dev host: rejected before any fetch.
+        let cap = Capability {
+            name: "dev.ucp.shopping.checkout".to_string(),
+            version: "2026-06-01".to_string(),
+            schema_url: "https://evil.example/checkout.json".to_string(),
+            extends: None,
+        };
+        let config = SchemaBaseConfig::default();
+        let err = compose_schema(&[cap], &config).unwrap_err();
+        assert!(matches!(
+            err,
+            ComposeError::NamespaceBindingViolation { .. }
+        ));
+    }
+
+    #[test]
+    fn compose_skips_binding_for_non_url_schema() {
+        // A local-path schema value has no origin, so the binding does not apply;
+        // it fails later as a fetch error, never as a binding violation.
+        let cap = Capability {
+            name: "dev.ucp.shopping.checkout".to_string(),
+            version: "2026-06-01".to_string(),
+            schema_url: "checkout.json".to_string(),
+            extends: None,
+        };
+        let config = SchemaBaseConfig {
+            local_base: Some(Path::new("/nonexistent")),
+            ..Default::default()
+        };
+        let err = compose_schema(&[cap], &config).unwrap_err();
+        assert!(matches!(err, ComposeError::SchemaFetch { .. }));
+    }
+
+    #[test]
+    fn compose_allows_correctly_bound_schema_url() {
+        // ucp.dev authority matches dev.ucp.*: binding passes, so the error is a
+        // (local-mapped) fetch miss, NOT a binding violation — and stays offline.
+        let cap = Capability {
+            name: "dev.ucp.shopping.checkout".to_string(),
+            version: "2026-06-01".to_string(),
+            schema_url: "https://ucp.dev/draft/schemas/shopping/checkout.json".to_string(),
+            extends: None,
+        };
+        let config = SchemaBaseConfig {
+            local_base: Some(Path::new("/nonexistent")),
+            remote_base: Some("https://ucp.dev/draft"),
+        };
+        let err = compose_schema(&[cap], &config).unwrap_err();
+        assert!(matches!(err, ComposeError::SchemaFetch { .. }));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,9 @@ pub enum ComposeError {
         range: String,
         actual: String,
     },
+
+    #[error("capability '{capability}' fails namespace authority binding: {message}")]
+    NamespaceBindingViolation { capability: String, message: String },
 }
 
 impl ComposeError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ mod compose;
 mod error;
 mod linter;
 mod loader;
+mod namespace;
 mod resolver;
 mod types;
 mod validator;
@@ -74,6 +75,7 @@ pub use loader::{
     bundle_refs, bundle_refs_with_url_mapping, is_url, load_schema, load_schema_auto,
     load_schema_str, navigate_fragment,
 };
+pub use namespace::{reverse_labels, validate_binding, BindingError};
 pub use resolver::{resolve, strip_annotations};
 pub use types::{Direction, Requires, ResolveOptions, VersionConstraint, Visibility};
 pub use validator::{select_operation_schema, validate, validate_against_schema};

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -156,6 +156,9 @@ pub fn lint_file(file: &Path, base_path: &Path) -> FileResult {
     // Check `requires` field (version constraints on extension schemas)
     check_requires(&schema, file, &mut diagnostics);
 
+    // Check that `examples` entries validate against their own (sub)schema
+    check_examples(&schema, file, "", &mut diagnostics);
+
     // Check for missing $id (warning)
     if schema.get("$id").is_none() {
         diagnostics.push(Diagnostic {
@@ -182,6 +185,53 @@ pub fn lint_file(file: &Path, base_path: &Path) -> FileResult {
         file: file.strip_prefix(base_path).unwrap_or(file).to_path_buf(),
         status,
         diagnostics,
+    }
+}
+
+/// Validate that every `examples` entry conforms to its enclosing (sub)schema.
+///
+/// `examples` is an annotation that validators ignore, so a listed value that
+/// does not satisfy the schema is an authoring bug or a grammar regression
+/// (e.g., narrowing a `pattern` until a documented-valid value stops matching).
+/// This turns `examples` into an executable, drift-free conformance battery that
+/// lives next to the grammar it documents.
+///
+/// Best-effort: a sub-schema whose validator cannot be compiled in isolation
+/// (e.g., unresolved external `$ref`s) is skipped here — broken refs are already
+/// reported by the `$ref` checks.
+fn check_examples(value: &Value, file: &Path, path: &str, diagnostics: &mut Vec<Diagnostic>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::Array(examples)) = map.get("examples") {
+                if let Ok(validator) = jsonschema::validator_for(value) {
+                    for (i, example) in examples.iter().enumerate() {
+                        if !validator.is_valid(example) {
+                            diagnostics.push(Diagnostic {
+                                severity: Severity::Error,
+                                code: "E008".to_string(),
+                                file: file.to_path_buf(),
+                                path: format!("{}/examples/{}", path, i),
+                                message: format!(
+                                    "example does not validate against its schema: {}",
+                                    example
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+            for (key, child) in map {
+                let child_path = format!("{}/{}", path, key);
+                check_examples(child, file, &child_path, diagnostics);
+            }
+        }
+        Value::Array(items) => {
+            for (i, item) in items.iter().enumerate() {
+                let child_path = format!("{}/{}", path, i);
+                check_examples(item, file, &child_path, diagnostics);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -759,6 +809,60 @@ mod tests {
         let result = lint_file(file.path(), file.path().parent().unwrap());
         assert_eq!(result.status, FileStatus::Ok);
         assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn lint_valid_examples_pass() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/rdn.json",
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*(?:\\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$",
+            "examples": ["dev.ucp.shopping.checkout", "com.example-shop.checkout", "co.uk"]
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert!(
+            !result.diagnostics.iter().any(|d| d.code == "E008"),
+            "valid examples should not produce E008: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn lint_invalid_example_fails() {
+        // A documented-valid example that no longer matches the pattern (e.g.,
+        // after a grammar regression) MUST be flagged.
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/rdn.json",
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*(?:\\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$",
+            "examples": ["dev.ucp.shopping.checkout", "com.-INVALID"]
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Error);
+        let e008: Vec<_> = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "E008")
+            .collect();
+        assert_eq!(
+            e008.len(),
+            1,
+            "expected one E008, got {:?}",
+            result.diagnostics
+        );
+        assert_eq!(e008[0].path, "/examples/1");
     }
 
     #[test]

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,0 +1,331 @@
+//! Namespace authority binding validation (UCP §Authority Binding).
+//!
+//! Validates that a capability's `schema` URL origin matches the reverse-domain
+//! authority encoded in the capability name.
+//!
+//! # Why the *inverted* strategy
+//!
+//! A capability name like `com.example.pay` follows the grammar
+//! `{reverse-domain}.{service}.{capability}`. Every component is dot-separated
+//! and DNS domains are variable-depth, so the boundary between the authority
+//! domain and the service/capability suffix is **not** recoverable from the
+//! name alone — `com.example.pay` could be authority `example.com` + `pay`, or a
+//! three-label domain, and disambiguating requires the Public Suffix List and
+//! is *still* ambiguous for single-suffix vendor names (`org.example.catalog`).
+//!
+//! So we do not derive the domain from the name. We read it from the
+//! authoritative source we already hold: the declared `schema` URL host.
+//! We reverse the host's labels into a prefix and assert the capability name is
+//! namespaced under it. This is deterministic, PSL-free, and the
+//! service/capability suffix stays **opaque** (never parsed).
+//!
+//! # The rule
+//!
+//! For a URL `U` declared by capability `name`:
+//! 1. `U` MUST parse, use scheme `https`, and carry no userinfo (`user:pass@`).
+//! 2. `U`'s host MUST be a registered domain name: at least two labels, not an
+//!    IP literal.
+//! 3. `reverse_labels(host)` MUST be a **label-boundary** prefix of `name`
+//!    (i.e. `name` starts with `reverse_labels(host) + "."`). The trailing dot
+//!    both prevents sibling-prefix spoofing (`examplepay.com` vs `example.com`) and
+//!    guarantees a non-empty service/capability remainder.
+//!
+//! This binding applies to the **`schema`** URL — the machine-fetched artifact
+//! that defines the wire contract and the thing compose dereferences. The
+//! **`spec`** URL (human documentation) is not in the machine trust path and is
+//! not authority-bound by this module.
+//!
+//! # Scope (what this does NOT prove)
+//!
+//! Binding proves the schema is *hosted on the domain that owns the namespace*.
+//! It does not prove content authenticity, survive DNS/domain hijack, or re-check
+//! anything once a schema is cached. It is anti-spoofing of namespace provenance,
+//! not capability authorization or trust.
+//!
+//! # Internationalized domains
+//!
+//! IDN hosts normalize to punycode (`xn--…`) via the URL parser, and the binding
+//! is a pure label-reversal + prefix check, so internationalized authorities
+//! — including IDN TLDs (e.g. `.рф` → `xn--p1ai`) — bind correctly with no
+//! special handling.
+
+use url::{Host, Url};
+
+/// Reason a `(name, url)` binding failed validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindingError {
+    /// The URL string could not be parsed.
+    Unparsable { url: String, reason: String },
+    /// Scheme is not `https` (downgrade / non-fetchable origin).
+    NonHttpsScheme { url: String, scheme: String },
+    /// URL carries userinfo (`user:pass@host`) — classic parser-confusion vector.
+    Userinfo { url: String },
+    /// Host is missing, an IP literal, or a single-label (non-registered) name.
+    NonDomainHost { url: String },
+    /// Host origin does not match the capability's namespace authority.
+    AuthorityMismatch {
+        name: String,
+        url: String,
+        host: String,
+        /// The reverse-domain prefix the name was required to start with.
+        expected_prefix: String,
+    },
+}
+
+impl std::fmt::Display for BindingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BindingError::Unparsable { url, reason } => {
+                write!(f, "unparsable URL '{url}': {reason}")
+            }
+            BindingError::NonHttpsScheme { url, scheme } => {
+                write!(f, "URL '{url}' must use https, found '{scheme}'")
+            }
+            BindingError::Userinfo { url } => {
+                write!(f, "URL '{url}' must not contain userinfo (user:pass@)")
+            }
+            BindingError::NonDomainHost { url } => write!(
+                f,
+                "URL '{url}' host must be a registered domain name (>=2 labels, not an IP)"
+            ),
+            BindingError::AuthorityMismatch {
+                name,
+                url,
+                host,
+                expected_prefix,
+            } => write!(
+                f,
+                "capability '{name}' is not namespaced under host '{host}' \
+                 (expected name to start with '{expected_prefix}.') for URL '{url}'"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BindingError {}
+
+/// Reverse a host's dot-separated labels: `shopping.ucp.dev` -> `dev.ucp.shopping`.
+///
+/// A trailing root dot is ignored so `example.com.` and `example.com` reverse identically.
+pub fn reverse_labels(host: &str) -> String {
+    host.trim_end_matches('.')
+        .split('.')
+        .rev()
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+/// Validate that `name`'s namespace authority matches the origin of its `schema`
+/// `url`.
+///
+/// See the module docs for the full rule. Returns `Ok(())` when the binding is
+/// sound, or a [`BindingError`] describing the first failing condition.
+pub fn validate_binding(name: &str, url: &str) -> Result<(), BindingError> {
+    let parsed = Url::parse(url).map_err(|e| BindingError::Unparsable {
+        url: url.to_string(),
+        reason: e.to_string(),
+    })?;
+
+    if parsed.scheme() != "https" {
+        return Err(BindingError::NonHttpsScheme {
+            url: url.to_string(),
+            scheme: parsed.scheme().to_string(),
+        });
+    }
+
+    // Reject userinfo before host inspection: `https://example.com@evil.com` parses
+    // host as `evil.com`, but a naive substring check would see `example.com`.
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(BindingError::Userinfo {
+            url: url.to_string(),
+        });
+    }
+
+    // `Host::Domain` is already lowercased and IDNA->punycode normalized by the
+    // parser; IP literals surface as `Host::Ipv4`/`Ipv6` and are rejected.
+    let host = match parsed.host() {
+        Some(Host::Domain(d)) => d.trim_end_matches('.').to_ascii_lowercase(),
+        _ => {
+            return Err(BindingError::NonDomainHost {
+                url: url.to_string(),
+            })
+        }
+    };
+
+    // A registered authority domain has at least two labels (rejects `localhost`).
+    if !host.contains('.') {
+        return Err(BindingError::NonDomainHost {
+            url: url.to_string(),
+        });
+    }
+
+    let expected_prefix = reverse_labels(&host);
+    // Label-boundary prefix: the trailing dot defeats `com.examplepay` matching
+    // `com.example` and guarantees a non-empty capability remainder.
+    if name.starts_with(&format!("{expected_prefix}.")) {
+        Ok(())
+    } else {
+        Err(BindingError::AuthorityMismatch {
+            name: name.to_string(),
+            url: url.to_string(),
+            host,
+            expected_prefix,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reverses_labels() {
+        assert_eq!(reverse_labels("example.com"), "com.example");
+        assert_eq!(reverse_labels("shopping.ucp.dev"), "dev.ucp.shopping");
+        assert_eq!(reverse_labels("example.co.uk"), "uk.co.example");
+        assert_eq!(reverse_labels("example.com."), "com.example");
+    }
+
+    #[test]
+    fn accepts_apex_authority() {
+        assert!(validate_binding("com.example.pay", "https://example.com/spec.json").is_ok());
+        assert!(validate_binding(
+            "dev.ucp.shopping.checkout",
+            "https://ucp.dev/draft/schemas/shopping/checkout.json"
+        )
+        .is_ok());
+        // Single-label remainder (vendor capability without an explicit service).
+        assert!(
+            validate_binding("org.example.catalog", "https://example.org/catalog.json").is_ok()
+        );
+        // Deeper authority domain.
+        assert!(validate_binding(
+            "uk.co.example.shopping.cart",
+            "https://example.co.uk/cart.json"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn accepts_name_aligned_subdomain() {
+        // Subdomain whose labels match the namespace path is the legitimate
+        // domain owner and is allowed without a PSL.
+        assert!(validate_binding(
+            "dev.ucp.shopping.checkout",
+            "https://shopping.ucp.dev/checkout.json"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn rejects_origin_mismatch() {
+        // The motivating case: com.example.pay pointing at an unrelated origin.
+        let err = validate_binding("com.example.pay", "https://foo.com/spec.json").unwrap_err();
+        assert!(matches!(err, BindingError::AuthorityMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_reserved_namespace_squat() {
+        // Only ucp.dev's owner can serve a passing dev.ucp.* capability.
+        let err =
+            validate_binding("dev.ucp.shopping.checkout", "https://evil.com/x.json").unwrap_err();
+        assert!(matches!(err, BindingError::AuthorityMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_sibling_prefix_spoof() {
+        // com.examplepay is a *string* prefix of com.example but not a *label* prefix.
+        let err = validate_binding("com.example.pay", "https://examplepay.com/x.json").unwrap_err();
+        assert!(matches!(err, BindingError::AuthorityMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_unrelated_subdomain() {
+        // S1 (no PSL): a CDN subdomain whose labels don't match the path is rejected.
+        let err =
+            validate_binding("com.example.pay", "https://cdn.example.com/x.json").unwrap_err();
+        assert!(matches!(err, BindingError::AuthorityMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_userinfo_confusion() {
+        let err =
+            validate_binding("com.example.pay", "https://example.com@evil.com/x.json").unwrap_err();
+        assert_eq!(
+            err,
+            BindingError::Userinfo {
+                url: "https://example.com@evil.com/x.json".into()
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_non_https() {
+        let err = validate_binding("com.example.pay", "http://example.com/x.json").unwrap_err();
+        assert!(matches!(err, BindingError::NonHttpsScheme { .. }));
+    }
+
+    #[test]
+    fn rejects_ip_literal() {
+        let err = validate_binding("com.example.pay", "https://93.184.216.34/x.json").unwrap_err();
+        assert!(matches!(err, BindingError::NonDomainHost { .. }));
+        let err6 = validate_binding("com.example.pay", "https://[2001:db8::1]/x.json").unwrap_err();
+        assert!(matches!(err6, BindingError::NonDomainHost { .. }));
+    }
+
+    #[test]
+    fn rejects_single_label_host() {
+        let err = validate_binding("localhost.pay", "https://localhost/x.json").unwrap_err();
+        assert!(matches!(err, BindingError::NonDomainHost { .. }));
+    }
+
+    #[test]
+    fn rejects_empty_remainder() {
+        // Host reverses to exactly the name => no capability label => reject.
+        let err = validate_binding("com.example", "https://example.com/x.json").unwrap_err();
+        assert!(matches!(err, BindingError::AuthorityMismatch { .. }));
+    }
+
+    #[test]
+    fn host_case_is_normalized() {
+        assert!(validate_binding("com.example.pay", "https://EXAMPLE.COM/x.json").is_ok());
+    }
+
+    #[test]
+    fn hyphenated_and_punycode_domains() {
+        // Interior hyphens (real merchant domains) bind correctly — the check is
+        // label-boundary, so hyphens are ordinary intra-label characters.
+        assert!(validate_binding(
+            "com.example-shop.shopping.checkout",
+            "https://example-shop.com/checkout.json"
+        )
+        .is_ok());
+        assert!(validate_binding(
+            "com.example-corp.loyalty",
+            "https://example-corp.com/x.json"
+        )
+        .is_ok());
+        // Punycode (IDN) SLD under an ASCII TLD binds the same way.
+        assert!(validate_binding(
+            "com.xn--mnchen-3ya.checkout",
+            "https://xn--mnchen-3ya.com/x.json"
+        )
+        .is_ok());
+        // IDN TLD (e.g. .рф -> xn--p1ai) as the reversed first segment also binds.
+        assert!(validate_binding(
+            "xn--p1ai.example.checkout",
+            "https://example.xn--p1ai/x.json"
+        )
+        .is_ok());
+        // An unrelated subdomain of a hyphenated domain still fails (S1 rule,
+        // not a hyphen issue): shop.example-co.com -> com.example-co.shop.
+        assert!(matches!(
+            validate_binding(
+                "com.example-co.shopping.cart",
+                "https://shop.example-co.com/cart.json"
+            )
+            .unwrap_err(),
+            BindingError::AuthorityMismatch { .. }
+        ));
+    }
+}


### PR DESCRIPTION
Spec PR: https://github.com/Universal-Commerce-Protocol/ucp/pull/530

Implements the spec's **Authority Binding** rule in the reference toolchain. Two user-visible behaviors:

1. **`compose`/`validate`/`resolve` now reject a capability whose `schema` URL isn't served from the domain that owns its reverse-domain namespace** — before any fetch.
2. **`ucp-schema lint` now fails (E008) if a schema's `examples` entry doesn't validate against that schema** — catching grammar regressions where a documented-valid value silently stops matching.

Enforcement is strict (the spec requires it) so the toolchain offers no opt-out. Schema values that aren't `http(s)` URLs (local paths) carry no origin and are skipped; that exemption is intrinsic, not a flag. Verifying the declared URL is independent of how the schema is then resolved, so it also runs (as a fail-fast lint) under `--schema-local-base`.

The authority is **not** parsed out of the dotted capability name — the boundary between the reverse-domain and the `{service}.{capability}` suffix isn't recoverable from a variable-depth dotted string. Instead it's read from the declared `schema` URL host, which names the owning domain unambiguously, then checked as a label-boundary prefix of the name:

```
host = ucp.dev   →   reverse labels   →   authority_prefix = "dev.ucp"
name must start with "dev.ucp."   (the trailing dot is load-bearing)
```

| Capability name | `schema` host | `authority_prefix` | Result |
| --- | --- | --- | --- |
| `dev.ucp.shopping.checkout` | `ucp.dev` | `dev.ucp` | ✅ accept |
| `dev.ucp.shopping.checkout` | `shopping.ucp.dev` | `dev.ucp.shopping` | ✅ accept |
| `com.example.payments.installments` | `example.com` | `com.example` | ✅ accept |
| `dev.ucp.shopping.checkout` | `evil.example` | `example.evil` | ❌ reject |
| `com.examplecorp.pay` | `example.com` | `com.example` | ❌ reject (label boundary) |
| `com.example.pay` | `cdn.example.com` | `com.example.cdn` | ❌ reject |

The `{service}.{capability}` remainder stays opaque (never parsed), so the check is deterministic and PSL-free. It's encoding-agnostic, so internationalized (punycode) authorities — including IDN TLDs — bind with no special handling. The trailing-dot boundary defeats sibling-prefix spoofing (`examplepay.com` can't claim `com.example.*`), and parsing with the `url` crate defeats userinfo confusion (`https://ucp.dev@evil.example/...` has host `evil.example`).

## Example: compose rejects a misattributed schema (before fetch)

```jsonc
// spoof.json — claims a reserved dev.ucp.* capability, served off a foreign host
{ "ucp": { "capabilities": {
  "dev.ucp.shopping.checkout": [
    { "version": "2026-06-01", "schema": "https://rando.example/checkout.json" }
  ]
} } }
```

```console
$ ucp-schema compose spoof.json ; echo "exit=$?"
Error: capability 'dev.ucp.shopping.checkout' fails namespace authority binding:
  capability 'dev.ucp.shopping.checkout' is not namespaced under host 'rando.example'
  (expected name to start with 'example.rando.') for URL 'https://rando.example/checkout.json'
exit=2
```

---

## Checklist 

- [x] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. 
- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md)
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
