### PR TITLE
fix: resolve self-root refs against their source file when bundling

### DIFF
--- a/src/compose.rs
+++ b/src/compose.rs
@@ -542,7 +542,7 @@ pub fn compose_schema(
 
         // Inline internal #/$defs/... refs so the extracted def is self-contained
         let mut inlined = ext_def.clone();
-        inline_internal_refs(&mut inlined, defs);
+        inline_internal_refs(&mut inlined, defs, &ext_schema);
 
         ext_defs.push(inlined);
     }
@@ -660,20 +660,98 @@ fn compose_container(
 /// When extracting a single definition from a schema, that definition may have
 /// internal refs to other definitions in the same schema. This function
 /// recursively inlines those refs so the extracted definition is self-contained.
+/// A `$ref: "#"` means the SOURCE file's root; it is resolved the same way the
+/// bundler does it (issue #43): inline the source root when that terminates,
+/// otherwise embed the source file as an `$id`'d `$defs` resource.
 ///
 /// # Arguments
 /// * `value` - The value to process (modified in place)
 /// * `defs` - The `$defs` object to resolve refs against
-fn inline_internal_refs(value: &mut Value, defs: &Value) {
-    inline_internal_refs_inner(value, defs, &mut HashSet::new());
+/// * `source_root` - Root of the schema file `value` was extracted from
+fn inline_internal_refs(value: &mut Value, defs: &Value, source_root: &Value) {
+    inline_internal_refs_inner(value, defs, source_root, &mut HashSet::new());
 }
 
-fn inline_internal_refs_inner(value: &mut Value, defs: &Value, visited: &mut HashSet<String>) {
+/// Resolve a `$ref: "#"` site in an extracted definition (compose twin of the
+/// loader's `inline_self_root_ref`; the source schema is already bundled here,
+/// so no file loading is involved).
+fn inline_self_root_ref_composed(
+    obj: &mut serde_json::Map<String, Value>,
+    defs: &Value,
+    source_root: &Value,
+    visited: &mut HashSet<String>,
+) {
+    obj.remove("$ref");
+    // Sibling keywords at the site are ordinary subschemas from the same
+    // source file; resolve their refs too.
+    for value in obj.values_mut() {
+        inline_internal_refs_inner(value, defs, source_root, visited);
+    }
+
+    const VISIT_KEY: &str = "self-root|";
+    let root_copy = crate::loader::root_schema_copy(source_root);
+    if !visited.contains(VISIT_KEY) && !crate::loader::contains_self_root_ref(&root_copy) {
+        let mut attempt = root_copy;
+        // The attempt is committed unconditionally: nested "#" sites that
+        // cycle back here (VISIT_KEY present) are settled inside the attempt
+        // by the embedded-resource fallback below. Discarding an attempt
+        // would leak that fallback's bookkeeping in `visited` and leave a
+        // `$ref` pointing at a resource that was never materialized.
+        visited.insert(VISIT_KEY.to_string());
+        inline_internal_refs_inner(&mut attempt, defs, source_root, visited);
+        visited.remove(VISIT_KEY);
+        let committed = crate::loader::attach_resolved_self_root(obj, attempt);
+        if committed {
+            return;
+        }
+    }
+    // Cycle through the source root: embed the source file with its $id
+    // (synthesized when missing) and point the ref at it — "#" inside the
+    // embedded copy then resolves against that $id, and the rewritten `$ref`
+    // applies in conjunction with the remaining siblings.
+    let id = match source_root.get("$id").and_then(|v| v.as_str()) {
+        Some(id) => id.to_string(),
+        None => crate::loader::synthesized_root_id(source_root),
+    };
+    let embed_marker = format!("embedded|{}", id);
+    if !visited.contains(&embed_marker) {
+        visited.insert(embed_marker);
+        let mut resource = source_root.clone();
+        if let Value::Object(res_obj) = &mut resource {
+            res_obj
+                .entry("$id")
+                .or_insert_with(|| Value::String(id.clone()));
+        }
+        let defs_slot = obj
+            .entry("$defs")
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        if let Value::Object(defs_obj) = defs_slot {
+            let mut key = "bundled_self_root".to_string();
+            let mut n = 1;
+            while defs_obj.contains_key(&key) {
+                n += 1;
+                key = format!("bundled_self_root_{}", n);
+            }
+            defs_obj.insert(key, resource);
+        }
+    }
+    obj.insert("$ref".to_string(), Value::String(id));
+}
+
+fn inline_internal_refs_inner(
+    value: &mut Value,
+    defs: &Value,
+    source_root: &Value,
+    visited: &mut HashSet<String>,
+) {
     match value {
         Value::Object(obj) => {
             // Check if this object has an internal $ref
             if let Some(ref_val) = obj.get("$ref").and_then(|v| v.as_str()) {
-                // Only handle internal refs to $defs (not self-root "#" refs)
+                if ref_val == "#" {
+                    inline_self_root_ref_composed(obj, defs, source_root, visited);
+                    return;
+                }
                 if let Some(def_name) = ref_val.strip_prefix("#/$defs/") {
                     // Guard against circular refs
                     if visited.contains(def_name) {
@@ -686,7 +764,7 @@ fn inline_internal_refs_inner(value: &mut Value, defs: &Value, visited: &mut Has
 
                         // Clone and recursively inline
                         let mut inlined = def.clone();
-                        inline_internal_refs_inner(&mut inlined, defs, visited);
+                        inline_internal_refs_inner(&mut inlined, defs, source_root, visited);
 
                         visited.remove(def_name);
 
@@ -704,12 +782,12 @@ fn inline_internal_refs_inner(value: &mut Value, defs: &Value, visited: &mut Has
 
             // Recurse into all values
             for v in obj.values_mut() {
-                inline_internal_refs_inner(v, defs, visited);
+                inline_internal_refs_inner(v, defs, source_root, visited);
             }
         }
         Value::Array(arr) => {
             for item in arr {
-                inline_internal_refs_inner(item, defs, visited);
+                inline_internal_refs_inner(item, defs, source_root, visited);
             }
         }
         _ => {}
@@ -926,6 +1004,48 @@ fn extract_url_path(url: &str) -> Result<String, ComposeError> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn inline_internal_refs_cycle_commits_attempt_without_dangling_refs() {
+        // Un-bundled source: the root references back into the very $defs
+        // entry being extracted, and that entry references the root via "#".
+        // Extraction must terminate with every emitted $ref backed by a
+        // materialized resource — a discarded inline attempt that leaks its
+        // embed bookkeeping leaves a $ref to a resource that was never
+        // materialized, and the extracted def no longer compiles.
+        let source: Value = serde_json::from_str(
+            r##"{
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "next": { "$ref": "#/$defs/wrapped" }
+                },
+                "$defs": {
+                    "wrapped": {
+                        "allOf": [
+                            { "$ref": "#" },
+                            {
+                                "type": "object",
+                                "properties": { "wrapped": { "type": "boolean" } }
+                            }
+                        ]
+                    }
+                }
+            }"##,
+        )
+        .unwrap();
+        let defs = source.get("$defs").unwrap().clone();
+        let mut extracted = defs.get("wrapped").unwrap().clone();
+        inline_internal_refs(&mut extracted, &defs, &source);
+
+        let validator = jsonschema::validator_for(&extracted)
+            .expect("extracted def must compile (no dangling refs)");
+        assert!(validator.is_valid(
+            &json!({"name": "a", "wrapped": true, "next": {"name": "b", "wrapped": false}})
+        ));
+        // "name" is typed at the source root, reached via "#".
+        assert!(!validator.is_valid(&json!({"name": 1})));
+    }
 
     #[test]
     fn detect_direction_response() {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -114,13 +114,227 @@ pub fn navigate_fragment(schema: &Value, fragment: &str) -> Result<Value, Resolv
     Ok(current.clone())
 }
 
+/// True if any `$ref: "#"` occurs anywhere in the value.
+pub(crate) fn contains_self_root_ref(value: &Value) -> bool {
+    match value {
+        Value::Object(obj) => {
+            if obj.get("$ref").and_then(|v| v.as_str()) == Some("#") {
+                return true;
+            }
+            obj.values().any(contains_self_root_ref)
+        }
+        Value::Array(arr) => arr.iter().any(contains_self_root_ref),
+        _ => false,
+    }
+}
+
+/// Copy of a file's root schema suitable for inlining at a `$ref: "#"` site:
+/// `$defs` is dropped (internal refs are resolved against the original file),
+/// and `$id`/`$schema` are dropped so the copy doesn't open a new resource
+/// scope at the inline site.
+pub(crate) fn root_schema_copy(file_root: &Value) -> Value {
+    let mut copy = file_root.clone();
+    if let Value::Object(obj) = &mut copy {
+        obj.remove("$defs");
+        obj.remove("$id");
+        obj.remove("$schema");
+    }
+    copy
+}
+
+/// Stable (FNV-1a) hash so synthesized resource ids are deterministic across
+/// builds, unlike `DefaultHasher`.
+pub(crate) fn stable_hash(s: &str) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in s.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// Identity of a source file for cycle bookkeeping: its `$id` when present,
+/// otherwise a content hash.
+fn self_root_identity(file_root: &Value) -> String {
+    match file_root.get("$id").and_then(|v| v.as_str()) {
+        Some(id) => id.to_string(),
+        None => format!("{:016x}", stable_hash(&file_root.to_string())),
+    }
+}
+
+/// Deterministic resource id for a file that has no `$id` of its own,
+/// derived from the file's content so distinct files never collide.
+pub(crate) fn synthesized_root_id(file_root: &Value) -> String {
+    format!(
+        "urn:ucp-schema:bundled-root:{:016x}",
+        stable_hash(&file_root.to_string())
+    )
+}
+
+/// Attach a schema resolved from a `$ref: "#"` site to that site's object
+/// (whose `$ref` has already been removed). With no sibling keywords the
+/// schema is spliced in directly; with siblings, 2020-12 requires the ref'd
+/// schema to apply in CONJUNCTION with them, so it is pushed into `allOf`.
+/// Returns false when the site has a malformed (non-array) `allOf`, in which
+/// case the caller should use the embedded-resource form instead.
+pub(crate) fn attach_resolved_self_root(
+    obj: &mut serde_json::Map<String, Value>,
+    resolved: Value,
+) -> bool {
+    if obj.is_empty() {
+        if let Value::Object(root_obj) = resolved {
+            for (k, v) in root_obj {
+                obj.insert(k, v);
+            }
+        }
+        return true;
+    }
+    match obj.get_mut("allOf") {
+        None => {
+            obj.insert("allOf".to_string(), Value::Array(vec![resolved]));
+            true
+        }
+        Some(Value::Array(arr)) => {
+            arr.push(resolved);
+            true
+        }
+        Some(_) => false,
+    }
+}
+
+/// Resolve a `$ref: "#"` site inside content extracted from source file
+/// `src_root` so it keeps meaning that file's root after bundling (issue #43).
+///
+/// Sibling keywords at the site are bundled first — they are ordinary
+/// subschemas written in the same source file. Preferred strategy for the ref
+/// itself: inline a copy of the source file's root schema at the site (in
+/// conjunction with any siblings). When that cannot terminate (the root itself
+/// contains `$ref: "#"`, or resolving it cycles back into this site), fall
+/// back to embedding the whole source file as a `$defs` resource with its
+/// `$id` intact (synthesized when missing) and rewriting the ref to that id —
+/// under 2020-12 embedded-resource rules, `#` inside the embedded copy then
+/// resolves against its own `$id`, and the rewritten `$ref` applies in
+/// conjunction with the remaining siblings.
+fn inline_self_root_ref(
+    obj: &mut serde_json::Map<String, Value>,
+    src_root: &Value,
+    base_dir: &Path,
+    url_local_base: Option<&Path>,
+    url_remote_base: Option<&str>,
+    visited: &mut std::collections::HashSet<String>,
+) -> Result<(), ResolveError> {
+    obj.remove("$ref");
+    for value in obj.values_mut() {
+        bundle_refs_inner(
+            value,
+            base_dir,
+            Some(src_root),
+            Some(src_root),
+            url_local_base,
+            url_remote_base,
+            visited,
+        )?;
+    }
+
+    let visit_key = format!("self-root|{}", self_root_identity(src_root));
+    let root_copy = root_schema_copy(src_root);
+    if !visited.contains(&visit_key) && !contains_self_root_ref(&root_copy) {
+        // Attempt the inline on cloned state so a cycle detected mid-way can
+        // fall back cleanly without corrupting the caller's bookkeeping.
+        let mut attempt = root_copy;
+        let mut attempt_visited = visited.clone();
+        attempt_visited.insert(visit_key.clone());
+        if bundle_refs_inner(
+            &mut attempt,
+            base_dir,
+            Some(src_root),
+            Some(src_root),
+            url_local_base,
+            url_remote_base,
+            &mut attempt_visited,
+        )
+        .is_ok()
+        {
+            attempt_visited.remove(&visit_key);
+            let committed = attach_resolved_self_root(obj, attempt);
+            if committed {
+                *visited = attempt_visited;
+                return Ok(());
+            }
+        }
+    }
+    embed_self_root_resource(
+        obj,
+        src_root,
+        base_dir,
+        url_local_base,
+        url_remote_base,
+        visited,
+    )
+}
+
+/// Fallback for [`inline_self_root_ref`]: embed the source file as a `$defs`
+/// resource (with `$id`) and point the ref at it. The embedded copy is only
+/// materialized once per source file; later sites just reuse the id.
+fn embed_self_root_resource(
+    obj: &mut serde_json::Map<String, Value>,
+    src_root: &Value,
+    base_dir: &Path,
+    url_local_base: Option<&Path>,
+    url_remote_base: Option<&str>,
+    visited: &mut std::collections::HashSet<String>,
+) -> Result<(), ResolveError> {
+    let id = match src_root.get("$id").and_then(|v| v.as_str()) {
+        Some(id) => id.to_string(),
+        None => synthesized_root_id(src_root),
+    };
+    let embed_marker = format!("embedded|{}", id);
+    if !visited.contains(&embed_marker) {
+        visited.insert(embed_marker);
+        let mut resource = src_root.clone();
+        if let Value::Object(res_obj) = &mut resource {
+            res_obj
+                .entry("$id")
+                .or_insert_with(|| Value::String(id.clone()));
+        }
+        // Bundle only the embedded copy's external refs. Its internal refs
+        // ("#" and "#/...") now sit under the resource's own $id and already
+        // mean the right thing, so no file_root/self context is passed.
+        bundle_refs_inner(
+            &mut resource,
+            base_dir,
+            None,
+            None,
+            url_local_base,
+            url_remote_base,
+            visited,
+        )?;
+        let defs = obj
+            .entry("$defs")
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        if let Value::Object(defs_obj) = defs {
+            let mut key = "bundled_self_root".to_string();
+            let mut n = 1;
+            while defs_obj.contains_key(&key) {
+                n += 1;
+                key = format!("bundled_self_root_{}", n);
+            }
+            defs_obj.insert(key, resource);
+        }
+    }
+    obj.insert("$ref".to_string(), Value::String(id));
+    Ok(())
+}
+
 /// Recursively resolve and inline external $ref pointers.
 ///
 /// Walks the schema tree, finds `$ref` values pointing to external files,
 /// loads them, and replaces the $ref with the loaded content.
 /// Internal refs (`#/...`) in the root schema are left for the validator.
 /// Internal refs in loaded external files are resolved against that file.
-/// Self-root refs (`$ref: "#"`) are left as-is (recursive type definitions).
+/// A `$ref: "#"` at document level is left as-is (it keeps meaning the
+/// document root); inside inlined fragments it is resolved against the file
+/// it was written in (see [`inline_self_root_ref`]).
 ///
 /// # Arguments
 /// * `schema` - The schema to process (modified in place)
@@ -132,6 +346,7 @@ pub fn bundle_refs(schema: &mut Value, base_dir: &Path) -> Result<(), ResolveErr
         schema,
         base_dir,
         Some(&root_snapshot),
+        None,
         None,
         None,
         &mut std::collections::HashSet::new(),
@@ -161,6 +376,7 @@ pub fn bundle_refs_with_url_mapping(
         schema,
         base_dir,
         Some(&root_snapshot),
+        None,
         Some(local_base),
         Some(remote_base),
         &mut std::collections::HashSet::new(),
@@ -171,6 +387,8 @@ fn bundle_refs_inner(
     schema: &mut Value,
     base_dir: &Path,
     file_root: Option<&Value>, // Root of external file for resolving internal refs
+    self_root: Option<&Value>, // Set when processing a fragment extracted from an
+    // external file: the root that `$ref: "#"` refers to
     url_local_base: Option<&Path>,
     url_remote_base: Option<&str>,
     visited: &mut std::collections::HashSet<String>,
@@ -181,9 +399,23 @@ fn bundle_refs_inner(
             if let Some(ref_val) = obj.get("$ref").and_then(|v| v.as_str()) {
                 if ref_val.starts_with('#') {
                     // Internal ref - only resolve if we have a file_root context
-                    // Skip self-root refs ($ref: "#") - these are recursive type defs
                     if ref_val == "#" {
-                        // Leave as-is - can't inline recursive self-reference
+                        if let Some(src) = self_root {
+                            // Inside an inlined fragment "#" means the SOURCE
+                            // file's root, which is about to disappear from
+                            // scope — resolve it now (issue #43).
+                            inline_self_root_ref(
+                                obj,
+                                src,
+                                base_dir,
+                                url_local_base,
+                                url_remote_base,
+                                visited,
+                            )?;
+                            return Ok(());
+                        }
+                        // Document-level "#" keeps meaning the document root
+                        // after bundling — leave as-is.
                     } else if let Some(root) = file_root {
                         let mut target = navigate_fragment(root, ref_val)?;
                         // Recursively process (may have nested refs)
@@ -191,6 +423,7 @@ fn bundle_refs_inner(
                             &mut target,
                             base_dir,
                             file_root,
+                            self_root,
                             url_local_base,
                             url_remote_base,
                             visited,
@@ -251,12 +484,37 @@ fn bundle_refs_inner(
                         loaded.clone()
                     };
 
+                    // Self-root ("#") context for the inlined content:
+                    // - A fragment loses its file's $id, so "#" inside it must
+                    //   be resolved against the source file (issue #43).
+                    // - A whole-file inline keeps the file's $id (the merge
+                    //   below carries it over), which is exactly what "#"
+                    //   binds to — but if the file has no $id, synthesize one
+                    //   so "#" doesn't escape to the inlining document root.
+                    let sub_self_root = if fragment.is_some() {
+                        Some(&loaded)
+                    } else {
+                        if loaded.get("$id").is_none() && contains_self_root_ref(&target) {
+                            if let Value::Object(target_obj) = &mut target {
+                                // Content-derived id: two different $id-less
+                                // files inlined under the same relative ref
+                                // text must not collide.
+                                target_obj.insert(
+                                    "$id".to_string(),
+                                    Value::String(synthesized_root_id(&loaded)),
+                                );
+                            }
+                        }
+                        None
+                    };
+
                     visited.insert(visit_key.clone());
                     // Pass loaded file as file_root so internal refs resolve against it
                     bundle_refs_inner(
                         &mut target,
                         &ref_dir_owned,
                         Some(&loaded),
+                        sub_self_root,
                         url_local_base,
                         url_remote_base,
                         visited,
@@ -279,6 +537,7 @@ fn bundle_refs_inner(
                     value,
                     base_dir,
                     file_root,
+                    self_root,
                     url_local_base,
                     url_remote_base,
                     visited,
@@ -291,6 +550,7 @@ fn bundle_refs_inner(
                     item,
                     base_dir,
                     file_root,
+                    self_root,
                     url_local_base,
                     url_remote_base,
                     visited,
@@ -342,8 +602,87 @@ pub fn bundle_refs_remote(schema: &mut Value, base_url: &str) -> Result<(), Reso
         schema,
         base_url,
         Some(&root_snapshot),
+        None,
         &mut std::collections::HashSet::new(),
     )
+}
+
+/// Remote twin of [`inline_self_root_ref`]: same strategy, HTTP loading.
+#[cfg(feature = "remote")]
+fn inline_self_root_ref_remote(
+    obj: &mut serde_json::Map<String, Value>,
+    src_root: &Value,
+    base_url: &str,
+    visited: &mut std::collections::HashSet<String>,
+) -> Result<(), ResolveError> {
+    obj.remove("$ref");
+    for value in obj.values_mut() {
+        bundle_refs_remote_inner(value, base_url, Some(src_root), Some(src_root), visited)?;
+    }
+
+    let visit_key = format!("self-root|{}", self_root_identity(src_root));
+    let root_copy = root_schema_copy(src_root);
+    if !visited.contains(&visit_key) && !contains_self_root_ref(&root_copy) {
+        let mut attempt = root_copy;
+        let mut attempt_visited = visited.clone();
+        attempt_visited.insert(visit_key.clone());
+        if bundle_refs_remote_inner(
+            &mut attempt,
+            base_url,
+            Some(src_root),
+            Some(src_root),
+            &mut attempt_visited,
+        )
+        .is_ok()
+        {
+            attempt_visited.remove(&visit_key);
+            let committed = attach_resolved_self_root(obj, attempt);
+            if committed {
+                *visited = attempt_visited;
+                return Ok(());
+            }
+        }
+    }
+    embed_self_root_resource_remote(obj, src_root, base_url, visited)
+}
+
+/// Remote twin of [`embed_self_root_resource`].
+#[cfg(feature = "remote")]
+fn embed_self_root_resource_remote(
+    obj: &mut serde_json::Map<String, Value>,
+    src_root: &Value,
+    base_url: &str,
+    visited: &mut std::collections::HashSet<String>,
+) -> Result<(), ResolveError> {
+    let id = match src_root.get("$id").and_then(|v| v.as_str()) {
+        Some(id) => id.to_string(),
+        None => synthesized_root_id(src_root),
+    };
+    let embed_marker = format!("embedded|{}", id);
+    if !visited.contains(&embed_marker) {
+        visited.insert(embed_marker);
+        let mut resource = src_root.clone();
+        if let Value::Object(res_obj) = &mut resource {
+            res_obj
+                .entry("$id")
+                .or_insert_with(|| Value::String(id.clone()));
+        }
+        bundle_refs_remote_inner(&mut resource, base_url, None, None, visited)?;
+        let defs = obj
+            .entry("$defs")
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        if let Value::Object(defs_obj) = defs {
+            let mut key = "bundled_self_root".to_string();
+            let mut n = 1;
+            while defs_obj.contains_key(&key) {
+                n += 1;
+                key = format!("bundled_self_root_{}", n);
+            }
+            defs_obj.insert(key, resource);
+        }
+    }
+    obj.insert("$ref".to_string(), Value::String(id));
+    Ok(())
 }
 
 #[cfg(feature = "remote")]
@@ -351,6 +690,7 @@ fn bundle_refs_remote_inner(
     schema: &mut Value,
     base_url: &str,
     file_root: Option<&Value>,
+    self_root: Option<&Value>,
     visited: &mut std::collections::HashSet<String>,
 ) -> Result<(), ResolveError> {
     match schema {
@@ -359,10 +699,22 @@ fn bundle_refs_remote_inner(
                 if ref_val.starts_with('#') {
                     // Internal ref
                     if ref_val == "#" {
-                        // Self-reference, leave as-is
+                        if let Some(src) = self_root {
+                            // "#" inside an inlined fragment means the source
+                            // file's root — resolve it now (issue #43).
+                            inline_self_root_ref_remote(obj, src, base_url, visited)?;
+                            return Ok(());
+                        }
+                        // Document-level self-reference, leave as-is
                     } else if let Some(root) = file_root {
                         let mut target = navigate_fragment(root, ref_val)?;
-                        bundle_refs_remote_inner(&mut target, base_url, file_root, visited)?;
+                        bundle_refs_remote_inner(
+                            &mut target,
+                            base_url,
+                            file_root,
+                            self_root,
+                            visited,
+                        )?;
                         obj.remove("$ref");
                         if let Value::Object(ref_obj) = target {
                             for (k, v) in ref_obj {
@@ -397,9 +749,30 @@ fn bundle_refs_remote_inner(
                         loaded.clone()
                     };
 
+                    // Same self-root handling as the local bundler: fragments
+                    // need "#" resolved against their source file; whole-file
+                    // inlines keep (or gain) an $id that "#" binds to.
+                    let sub_self_root = if fragment.is_some() {
+                        Some(&loaded)
+                    } else {
+                        if loaded.get("$id").is_none() && contains_self_root_ref(&target) {
+                            if let Value::Object(target_obj) = &mut target {
+                                target_obj
+                                    .insert("$id".to_string(), Value::String(resolved_url.clone()));
+                            }
+                        }
+                        None
+                    };
+
                     visited.insert(visit_key.clone());
                     // Recursively bundle with new base URL
-                    bundle_refs_remote_inner(&mut target, &resolved_url, Some(&loaded), visited)?;
+                    bundle_refs_remote_inner(
+                        &mut target,
+                        &resolved_url,
+                        Some(&loaded),
+                        sub_self_root,
+                        visited,
+                    )?;
                     visited.remove(&visit_key);
 
                     obj.remove("$ref");
@@ -414,12 +787,12 @@ fn bundle_refs_remote_inner(
 
             // Recurse into all values
             for value in obj.values_mut() {
-                bundle_refs_remote_inner(value, base_url, file_root, visited)?;
+                bundle_refs_remote_inner(value, base_url, file_root, self_root, visited)?;
             }
         }
         Value::Array(arr) => {
             for item in arr {
-                bundle_refs_remote_inner(item, base_url, file_root, visited)?;
+                bundle_refs_remote_inner(item, base_url, file_root, self_root, visited)?;
             }
         }
         _ => {}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -848,6 +848,532 @@ mod bundle {
             .success()
             // Self-root ref should be preserved (can't inline recursive)
             .stdout(predicate::str::contains(r##""$ref":"#""##));
+
+        // Preserving the "#" text is not enough: after bundling it must still
+        // RESOLVE to node.json's root, not to the bundled document root. A
+        // nested child with a non-string "value" violates node.json's schema;
+        // the bundled document root knows nothing about "value", so this
+        // rejection only happens when "#" keeps its original meaning.
+        let bad = write_temp_file(
+            &dir,
+            "bad.json",
+            r#"{"tree": {"value": "a", "children": [{"value": 1}]}}"#,
+        );
+        cmd()
+            .args([
+                "validate",
+                bad.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains(r#""valid":false"#));
+
+        let good = write_temp_file(
+            &dir,
+            "good.json",
+            r#"{"tree": {"value": "a", "children": [{"value": "b", "children": []}]}}"#,
+        );
+        cmd()
+            .args([
+                "validate",
+                good.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(r#""valid":true"#));
+    }
+
+    // Fixture mirroring the UCP payment chain (issue #43): outer.json ->
+    // mid.json -> types/instrument.json#/$defs/selected, where "selected" is
+    // an allOf whose first branch is {"$ref": "#"} — the instrument file's OWN
+    // root. After bundling, "#" must keep meaning the instrument root; the
+    // nearest enclosing $id at the inlined site belongs to mid.json, so a
+    // dangling "#" wrongly binds there.
+    fn write_self_root_ref_chain(dir: &TempDir) -> std::path::PathBuf {
+        fs::create_dir_all(dir.path().join("types")).unwrap();
+        fs::write(
+            dir.path().join("types/instrument.json"),
+            r##"{
+                "$id": "https://example.com/types/instrument.json",
+                "type": "object",
+                "required": ["id", "type"],
+                "properties": {
+                    "id": { "type": "string" },
+                    "type": { "type": "string" }
+                },
+                "additionalProperties": true,
+                "$defs": {
+                    "selected": {
+                        "allOf": [
+                            { "$ref": "#" },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "selected": { "type": "boolean" }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }"##,
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("mid.json"),
+            r##"{
+                "$id": "https://example.com/mid.json",
+                "type": "object",
+                "properties": {
+                    "instruments": {
+                        "type": "array",
+                        "items": { "$ref": "types/instrument.json#/$defs/selected" }
+                    }
+                }
+            }"##,
+        )
+        .unwrap();
+        write_temp_file(
+            dir,
+            "outer.json",
+            r#"{
+                "type": "object",
+                "properties": {
+                    "payment": { "$ref": "mid.json" }
+                }
+            }"#,
+        )
+    }
+
+    #[test]
+    fn bundled_fragment_self_root_ref_rejects_missing_required() {
+        let dir = TempDir::new().unwrap();
+        let schema = write_self_root_ref_chain(&dir);
+
+        // Instrument with NONE of the required fields must be rejected: the
+        // required list lives at instrument.json's root, reached via "#".
+        let payload = write_temp_file(
+            &dir,
+            "payload.json",
+            r#"{"payment": {"instruments": [{"selected": true}]}}"#,
+        );
+
+        cmd()
+            .args([
+                "validate",
+                payload.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--response",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains(r#""valid":false"#));
+    }
+
+    #[test]
+    fn bundled_fragment_self_root_ref_accepts_extra_sibling_named_key() {
+        let dir = TempDir::new().unwrap();
+        let schema = write_self_root_ref_chain(&dir);
+
+        // instrument.json's root allows additional properties, so an extra
+        // property that happens to share a name with a property of the
+        // INLINING file (mid.json's "instruments": array) must be accepted.
+        // If "#" wrongly binds to mid.json, "bogus" fails its array type.
+        let payload = write_temp_file(
+            &dir,
+            "payload.json",
+            r#"{"payment": {"instruments": [{"id": "i1", "type": "card", "instruments": "bogus"}]}}"#,
+        );
+
+        cmd()
+            .args([
+                "validate",
+                payload.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--response",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(r#""valid":true"#));
+    }
+
+    #[test]
+    fn bundled_fragment_self_root_ref_strict_accepts_valid_instrument() {
+        let dir = TempDir::new().unwrap();
+        let schema = write_self_root_ref_chain(&dir);
+
+        // Strict mode closes schemas against their declared properties. Those
+        // properties (id, type) are only visible when "#" resolves to
+        // instrument.json's root; a dangling "#" leaves every instrument field
+        // unevaluated and rejects even fully valid instruments.
+        let payload = write_temp_file(
+            &dir,
+            "payload.json",
+            r#"{"payment": {"instruments": [{"id": "i1", "type": "card", "selected": true}]}}"#,
+        );
+
+        cmd()
+            .args([
+                "validate",
+                payload.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--response",
+                "--op",
+                "create",
+                "--strict",
+                "true",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(r#""valid":true"#));
+    }
+
+    #[test]
+    fn bundle_self_root_site_siblings_conjoin_with_source_root() {
+        let dir = TempDir::new().unwrap();
+
+        // The "#" site carries sibling keywords that collide with the source
+        // root's keys (required, properties). 2020-12 applies $ref in
+        // conjunction with its siblings, so BOTH required lists must hold; a
+        // key-wise merge would drop the root's required:["a"].
+        fs::create_dir_all(dir.path().join("types")).unwrap();
+        fs::write(
+            dir.path().join("types/thing.json"),
+            r##"{
+                "$id": "https://example.com/thing.json",
+                "type": "object",
+                "required": ["a"],
+                "properties": { "a": { "type": "string" } },
+                "$defs": {
+                    "strict_thing": {
+                        "$ref": "#",
+                        "required": ["b"],
+                        "properties": { "b": { "type": "number" } }
+                    }
+                }
+            }"##,
+        )
+        .unwrap();
+        let schema = write_temp_file(
+            &dir,
+            "outer.json",
+            r##"{
+                "type": "object",
+                "properties": {
+                    "item": { "$ref": "types/thing.json#/$defs/strict_thing" }
+                }
+            }"##,
+        );
+
+        let bad = write_temp_file(&dir, "bad.json", r#"{"item": {"b": 1}}"#);
+        cmd()
+            .args([
+                "validate",
+                bad.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains(r#""valid":false"#));
+
+        let good = write_temp_file(&dir, "good.json", r#"{"item": {"a": "x", "b": 2}}"#);
+        cmd()
+            .args([
+                "validate",
+                good.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(r#""valid":true"#));
+    }
+
+    #[test]
+    fn bundle_self_root_site_sibling_refs_still_bundled() {
+        let dir = TempDir::new().unwrap();
+
+        // The "#" site has a sibling subtree containing its own external ref
+        // (other.json). Resolving "#" must not stop the bundler from also
+        // bundling the siblings — a dangling other.json ref makes the whole
+        // bundle uncompilable.
+        fs::create_dir_all(dir.path().join("types")).unwrap();
+        fs::write(
+            dir.path().join("types/thing.json"),
+            r##"{
+                "$id": "https://example.com/thing.json",
+                "type": "object",
+                "properties": { "a": { "type": "string" } },
+                "$defs": {
+                    "wrapped": {
+                        "$ref": "#",
+                        "properties": { "extra": { "$ref": "other.json" } }
+                    }
+                }
+            }"##,
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("types/other.json"),
+            r#"{ "type": "string", "minLength": 3 }"#,
+        )
+        .unwrap();
+        let schema = write_temp_file(
+            &dir,
+            "outer.json",
+            r##"{
+                "type": "object",
+                "properties": {
+                    "item": { "$ref": "types/thing.json#/$defs/wrapped" }
+                }
+            }"##,
+        );
+
+        let good = write_temp_file(&dir, "good.json", r#"{"item": {"extra": "abc"}}"#);
+        cmd()
+            .args([
+                "validate",
+                good.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(r#""valid":true"#));
+
+        let bad = write_temp_file(&dir, "bad.json", r#"{"item": {"extra": "ab"}}"#);
+        cmd()
+            .args([
+                "validate",
+                bad.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains("/item/extra"));
+    }
+
+    #[test]
+    fn bundle_synthesized_ids_distinct_for_distinct_files() {
+        let dir = TempDir::new().unwrap();
+
+        // Two DIFFERENT $id-less files are both referenced as "inner.json"
+        // (from different directories). Their synthesized resource ids must
+        // not collide, or "#" in one subtree binds to the other file's root.
+        fs::create_dir_all(dir.path().join("a")).unwrap();
+        fs::create_dir_all(dir.path().join("b")).unwrap();
+        fs::write(
+            dir.path().join("a/entry.json"),
+            r#"{"type":"object","properties":{"na":{"$ref":"inner.json"}}}"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("a/inner.json"),
+            r##"{"type":"object","required":["name"],"properties":{"name":{"type":"string"},"next":{"$ref":"#"}}}"##,
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("b/entry.json"),
+            r#"{"type":"object","properties":{"nb":{"$ref":"inner.json"}}}"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("b/inner.json"),
+            r##"{"type":"object","required":["count"],"properties":{"count":{"type":"number"},"next":{"$ref":"#"}}}"##,
+        )
+        .unwrap();
+        let schema = write_temp_file(
+            &dir,
+            "outer.json",
+            r#"{
+                "type": "object",
+                "properties": {
+                    "pa": { "$ref": "a/entry.json" },
+                    "pb": { "$ref": "b/entry.json" }
+                }
+            }"#,
+        );
+
+        // Recursion inside the "a" subtree follows a/inner.json's rules.
+        let good = write_temp_file(
+            &dir,
+            "good.json",
+            r#"{"pa":{"na":{"name":"x","next":{"name":"y"}}},"pb":{"nb":{"count":1,"next":{"count":2}}}}"#,
+        );
+        cmd()
+            .args([
+                "validate",
+                good.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(r#""valid":true"#));
+
+        // An a-subtree recursion step matching b/inner.json's shape (count,
+        // no name) must be rejected.
+        let bad = write_temp_file(
+            &dir,
+            "bad.json",
+            r#"{"pa":{"na":{"name":"x","next":{"count":123}}}}"#,
+        );
+        cmd()
+            .args([
+                "validate",
+                bad.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains(r#""valid":false"#));
+    }
+
+    #[test]
+    fn bundle_self_root_ref_cycle_through_defs_terminates() {
+        let dir = TempDir::new().unwrap();
+
+        // The source file's root references back into the very $defs entry
+        // being extracted, so inlining the root at the "#" site can never
+        // terminate by textual expansion. Bundling must still terminate and
+        // keep "#" meaning looper.json's root.
+        fs::create_dir_all(dir.path().join("types")).unwrap();
+        fs::write(
+            dir.path().join("types/looper.json"),
+            r##"{
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "next": { "$ref": "#/$defs/wrapped" }
+                },
+                "$defs": {
+                    "wrapped": {
+                        "allOf": [
+                            { "$ref": "#" },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "wrapped": { "type": "boolean" }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }"##,
+        )
+        .unwrap();
+        let schema = write_temp_file(
+            &dir,
+            "outer.json",
+            r#"{
+                "type": "object",
+                "properties": {
+                    "thing": { "$ref": "types/looper.json#/$defs/wrapped" }
+                }
+            }"#,
+        );
+
+        cmd()
+            .args([
+                "resolve",
+                schema.to_str().unwrap(),
+                "--request",
+                "--op",
+                "create",
+                "--bundle",
+            ])
+            .assert()
+            .success();
+
+        // "name" is typed at looper.json's root, reached via "#"; the outer
+        // document root does not type it.
+        let bad = write_temp_file(
+            &dir,
+            "bad.json",
+            r#"{"thing": {"name": 1, "wrapped": true}}"#,
+        );
+        cmd()
+            .args([
+                "validate",
+                bad.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains(r#""valid":false"#));
+
+        let good = write_temp_file(
+            &dir,
+            "good.json",
+            r#"{"thing": {"name": "a", "wrapped": true, "next": {"name": "b", "wrapped": false}}}"#,
+        );
+        cmd()
+            .args([
+                "validate",
+                good.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(r#""valid":true"#));
     }
 
     #[test]
@@ -1113,6 +1639,109 @@ mod remote {
     }
 
     #[test]
+    fn remote_bundle_resolves_fragment_self_root_ref_with_siblings() {
+        // Remote twin of the self-root-ref bundling fixes: a fragment fetched
+        // over HTTP whose "#" must keep meaning its source file's root, at a
+        // site that also carries a sibling subtree with its own external ref.
+        let mut server = mockito::Server::new();
+        let _outer = server
+            .mock("GET", "/schema.json")
+            .with_body(
+                r##"{
+                    "type": "object",
+                    "properties": {
+                        "item": { "$ref": "types/thing.json#/$defs/wrapped" }
+                    }
+                }"##,
+            )
+            .expect_at_least(1)
+            .create();
+        let _thing = server
+            .mock("GET", "/types/thing.json")
+            .with_body(
+                r##"{
+                    "type": "object",
+                    "required": ["root_marker"],
+                    "properties": { "root_marker": { "type": "string" } },
+                    "$defs": {
+                        "wrapped": {
+                            "$ref": "#",
+                            "properties": { "extra": { "$ref": "other.json" } }
+                        }
+                    }
+                }"##,
+            )
+            .expect_at_least(1)
+            .create();
+        let _other = server
+            .mock("GET", "/types/other.json")
+            .with_body(r#"{ "type": "string", "minLength": 3 }"#)
+            .expect_at_least(1)
+            .create();
+
+        let url = format!("{}/schema.json", server.url());
+        let dir = TempDir::new().unwrap();
+
+        // Source-root constraint enforced through "#".
+        let good = write_temp_file(
+            &dir,
+            "good.json",
+            r#"{"item": {"root_marker": "x", "extra": "abc"}}"#,
+        );
+        cmd()
+            .args([
+                "validate",
+                good.to_str().unwrap(),
+                "--schema",
+                &url,
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(r#""valid":true"#));
+
+        let missing_marker = write_temp_file(&dir, "bad1.json", r#"{"item": {"extra": "abc"}}"#);
+        cmd()
+            .args([
+                "validate",
+                missing_marker.to_str().unwrap(),
+                "--schema",
+                &url,
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains(r#""valid":false"#));
+
+        // Sibling subtree's external ref must still be bundled and enforced.
+        let short_extra = write_temp_file(
+            &dir,
+            "bad2.json",
+            r#"{"item": {"root_marker": "x", "extra": "ab"}}"#,
+        );
+        cmd()
+            .args([
+                "validate",
+                short_extra.to_str().unwrap(),
+                "--schema",
+                &url,
+                "--request",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains("/item/extra"));
+    }
+
+    #[test]
     fn validate_with_remote_schema() {
         let mut server = mockito::Server::new();
         let mock = server
@@ -1143,6 +1772,193 @@ mod remote {
 /// Schema composition tests - self-describing payloads
 mod compose {
     use super::*;
+
+    // Fixture for the compose-path self-root-ref tests: a root capability plus
+    // an extension whose $defs entry references the EXTENSION file's own root
+    // via "#" and carries colliding sibling keywords.
+    fn write_self_root_ref_capability_fixture(dir: &TempDir) {
+        fs::create_dir_all(dir.path().join("shopping")).unwrap();
+        fs::write(
+            dir.path().join("shopping/testbase.json"),
+            r#"{
+                "type": "object",
+                "additionalProperties": true,
+                "properties": { "core": { "type": "string" } }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("shopping/testext.json"),
+            r##"{
+                "type": "object",
+                "required": ["mark"],
+                "properties": { "mark": { "type": "string" } },
+                "additionalProperties": true,
+                "$defs": {
+                    "dev.ucp.shopping.testbase": {
+                        "$ref": "#",
+                        "required": ["flag"],
+                        "properties": { "flag": { "type": "boolean" } }
+                    }
+                }
+            }"##,
+        )
+        .unwrap();
+    }
+
+    const SELF_ROOT_REF_CAPS: &str = r#""ucp": {
+        "capabilities": {
+            "dev.ucp.shopping.testbase": [{
+                "version": "2026-01-11",
+                "schema": "https://ucp.dev/schemas/shopping/testbase.json"
+            }],
+            "dev.ucp.shopping.testext": [{
+                "version": "2026-01-11",
+                "schema": "https://ucp.dev/schemas/shopping/testext.json",
+                "extends": "dev.ucp.shopping.testbase"
+            }]
+        }
+    }"#;
+
+    #[test]
+    fn compose_extension_self_root_site_siblings_conjoin_with_extension_root() {
+        let dir = TempDir::new().unwrap();
+        write_self_root_ref_capability_fixture(&dir);
+
+        // The extension def's "#" means the extension FILE's root, whose
+        // required:["mark"] must apply in conjunction with the def site's own
+        // required:["flag"] — a key-wise merge would drop "mark".
+        let bad = write_temp_file(
+            &dir,
+            "bad.json",
+            &format!(r#"{{ {}, "flag": true }}"#, SELF_ROOT_REF_CAPS),
+        );
+        cmd()
+            .args([
+                "validate",
+                bad.to_str().unwrap(),
+                "--schema-local-base",
+                dir.path().to_str().unwrap(),
+                "--schema-remote-base",
+                "https://ucp.dev/schemas",
+                "--response",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains(r#""valid":false"#));
+
+        let good = write_temp_file(
+            &dir,
+            "good.json",
+            &format!(r#"{{ {}, "flag": true, "mark": "m" }}"#, SELF_ROOT_REF_CAPS),
+        );
+        cmd()
+            .args([
+                "validate",
+                good.to_str().unwrap(),
+                "--schema-local-base",
+                dir.path().to_str().unwrap(),
+                "--schema-remote-base",
+                "https://ucp.dev/schemas",
+                "--response",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(r#""valid":true"#));
+    }
+
+    #[test]
+    fn compose_extension_self_root_cycle_terminates() {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join("shopping")).unwrap();
+        fs::write(
+            dir.path().join("shopping/testbase.json"),
+            r#"{
+                "type": "object",
+                "additionalProperties": true,
+                "properties": { "core": { "type": "string" } }
+            }"#,
+        )
+        .unwrap();
+        // The extension file's root references back into the very $defs entry
+        // being extracted; composition must terminate with no dangling refs.
+        fs::write(
+            dir.path().join("shopping/testext.json"),
+            r##"{
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "next": { "$ref": "#/$defs/dev.ucp.shopping.testbase" }
+                },
+                "$defs": {
+                    "dev.ucp.shopping.testbase": {
+                        "allOf": [
+                            { "$ref": "#" },
+                            {
+                                "type": "object",
+                                "properties": { "wrapped": { "type": "boolean" } }
+                            }
+                        ]
+                    }
+                }
+            }"##,
+        )
+        .unwrap();
+
+        let good = write_temp_file(
+            &dir,
+            "good.json",
+            &format!(
+                r#"{{ {}, "name": "a", "wrapped": true, "next": {{ "name": "b", "wrapped": false }} }}"#,
+                SELF_ROOT_REF_CAPS
+            ),
+        );
+        cmd()
+            .args([
+                "validate",
+                good.to_str().unwrap(),
+                "--schema-local-base",
+                dir.path().to_str().unwrap(),
+                "--schema-remote-base",
+                "https://ucp.dev/schemas",
+                "--response",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(r#""valid":true"#));
+
+        // "name" is typed at the extension file's root, reached via "#".
+        let bad = write_temp_file(
+            &dir,
+            "bad.json",
+            &format!(r#"{{ {}, "name": 1 }}"#, SELF_ROOT_REF_CAPS),
+        );
+        cmd()
+            .args([
+                "validate",
+                bad.to_str().unwrap(),
+                "--schema-local-base",
+                dir.path().to_str().unwrap(),
+                "--schema-remote-base",
+                "https://ucp.dev/schemas",
+                "--response",
+                "--op",
+                "create",
+                "--json",
+            ])
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains(r#""valid":false"#));
+    }
 
     #[test]
     fn self_describing_checkout_only() {


### PR DESCRIPTION
Fixes #43.

## Observed

When the bundler inlines a referenced fragment, a `$ref: "#"` inside it is left as is; after bundling, the nearest enclosing `$id` belongs to the INLINING file, so the jsonschema crate resolves `#` to the wrong root (correctly, per 2020-12 embedded resource rules). In the 2026-04-08 UCP set this voids the `payment_instrument` base schema on every checkout payment path: an instrument with none of the required `id`, `handler_id`, `type` validates as `{"valid": true}`, a valid instrument with an extra property named `instruments` is rejected, and strict mode rejects every valid instrument. Details and reproduction in #43.

## Change

`#` inside an inlined fragment now keeps meaning the root of the file it was written in:

* `inline_self_root_ref` (local and remote loader paths, and the compose extraction path) removes the `$ref`, bundles any sibling values in the source file context first, then attaches the resolved source root: a direct splice when the site carries no siblings, or an `allOf` entry when it does, so sibling keywords compose by conjunction per 2020-12 rather than key merging.
* When the source root itself cycles (contains `#` or refs back into the fragment), the fallback embeds the source file once as a `$defs` resource with its `$id` intact (content derived id when the file has none, so distinct files can never collide) and rewrites `#` to point at it.
* `bundle_preserves_self_root_ref` now asserts the resolved SEMANTICS through validation, not just the preserved text; its previous form pinned the buggy binding.

## Verification

* New tests fail on unmodified main for the exact defects and pass with the change; the full suite is 326 passing (fmt, clippy with warnings denied, and release build clean). Coverage includes the local, remote (mockito) and compose paths, sibling conjunction, distinct synthesized ids, and cycle termination.
* Bundling all 78 schema files of the 2026-04-08 set in both request and response directions: zero failures, and the output differs from main in exactly the 7 files whose payment subtree contained the dangling `#` — nothing else changes.
* The issue's probe pair now agrees with an independent Python jsonschema referee on both CLI paths (explicit `--schema` and the self describing base path): the false accept rejects with the three required property errors, the false reject and the strict mode rejections accept.
* One evidence note for transparency: the compose path leak (a discarded extraction attempt leaving a dangling synthesized ref) is not reachable end to end through the CLI on current main because loader bundling resolves `#` before compose extraction sees one; it is pinned by a unit test at the function level, which is where the contract lives and where a future pipeline reordering would resurrect it.

Happy to split anything out or adjust the approach if you prefer one of the other directions sketched in #43.
