### PR TITLE
fix(linter): skip the $id check for OpenAPI and OpenRPC service definitions

### DIFF
--- a/src/linter.rs
+++ b/src/linter.rs
@@ -123,6 +123,15 @@ pub fn lint(path: &Path, strict: bool) -> LintResult {
     }
 }
 
+/// Whether a document is an OpenAPI or OpenRPC service definition rather than a
+/// JSON Schema. Both declare their version under a fixed root key (`openapi` /
+/// `openrpc`), which is how their own specifications identify the document type.
+fn is_service_definition(schema: &Value) -> bool {
+    ["openapi", "openrpc"]
+        .iter()
+        .any(|key| schema.get(key).is_some_and(Value::is_string))
+}
+
 /// Lint a single schema file.
 pub fn lint_file(file: &Path, base_path: &Path) -> FileResult {
     let mut diagnostics = Vec::new();
@@ -159,8 +168,10 @@ pub fn lint_file(file: &Path, base_path: &Path) -> FileResult {
     // Check that `examples` entries validate against their own (sub)schema
     check_examples(&schema, file, "", &mut diagnostics);
 
-    // Check for missing $id (warning)
-    if schema.get("$id").is_none() {
+    // Check for missing $id (warning). Service definitions are OpenAPI/OpenRPC
+    // documents, not JSON Schemas: neither root object defines $id, so requiring
+    // one would ask authors to add a key their own specification rejects.
+    if schema.get("$id").is_none() && !is_service_definition(&schema) {
         diagnostics.push(Diagnostic {
             severity: Severity::Warning,
             code: "W002".to_string(),
@@ -1081,6 +1092,61 @@ mod tests {
             r#"{{
             "type": "object",
             "properties": {{}}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Warning);
+        assert!(result.diagnostics.iter().any(|d| d.code == "W002"));
+    }
+
+    #[test]
+    fn lint_openapi_service_definition_skips_missing_id_warning() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "openapi": "3.1.0",
+            "info": {{ "title": "Shopping", "version": "1.0.0" }},
+            "paths": {{}}
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Ok);
+        assert!(!result.diagnostics.iter().any(|d| d.code == "W002"));
+    }
+
+    #[test]
+    fn lint_openrpc_service_definition_skips_missing_id_warning() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "openrpc": "1.3.2",
+            "info": {{ "title": "Shopping", "version": "1.0.0" }},
+            "methods": []
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Ok);
+        assert!(!result.diagnostics.iter().any(|d| d.code == "W002"));
+    }
+
+    #[test]
+    fn lint_non_string_openapi_property_still_warns() {
+        // A JSON Schema describing an OpenAPI document has an `openapi`
+        // property, but it is a subschema object, not a version string.
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "type": "object",
+            "properties": {{ "openapi": {{ "type": "string" }} }}
         }}"#
         )
         .unwrap();


### PR DESCRIPTION
## Summary

- Gate the `W002` "schema missing `$id`" warning on a document-type check.
- Add `is_service_definition()`: a document declaring a version string under a root
  `openapi` or `openrpc` key is a service definition, not a JSON Schema.
- Add three regression tests: OpenAPI skips the warning, OpenRPC skips the warning,
  and a JSON Schema that merely has a property *named* `openapi` still warns.

## Motivation

`lint_file` treats every `.json` file it is handed as a JSON Schema. OpenAPI and
OpenRPC documents are not JSON Schemas, and neither root object defines `$id` —
so the warning asks authors to add a key their own specification does not permit.

The effect is not cosmetic. On the UCP repository at `7dc6c11`:

```
$ ucp-schema lint --strict source/
✗ 100 files checked: 94 passed, 6 failed (0 errors, 6 warnings)
$ echo $?
1
```

All six failures are `W002`, and all six are service definitions:

| File | Root keys |
| --- | --- |
| `handlers/tokenization/openapi.json` | `openapi`, `info`, `paths` |
| `services/payment-actions/embedded.openrpc.json` | `openrpc`, `info`, `servers` |
| `services/shopping/embedded.openrpc.json` | `openrpc`, `info`, `servers` |
| `services/shopping/mcp.openrpc.json` | `openrpc`, `info`, `servers` |
| `services/shopping/permalink.openapi.json` | `openapi`, `info`, `servers` |
| `services/shopping/rest.openapi.json` | `openapi`, `info`, `servers` |

Zero genuine JSON Schema files in that tree lack `$id`. So `--strict` reports a
100% false-positive rate on the UCP source tree, and the flag cannot be adopted
in CI — the one thing it currently blocks on is a warning that does not apply.

## Scope

Only the `W002` check is gated. `$ref` resolution, `ucp_*` annotation checks,
`requires` checks and the `examples` conformance check continue to run on service
definitions unchanged — those documents do carry `$ref`s, and a broken one there
is still a real defect worth reporting.

The detection deliberately requires the root value to be a **string**. A JSON
Schema that describes an OpenAPI document has an `openapi` *property* whose value
is a subschema object; that must keep warning, and the third test pins it.

## Validation

- `cargo test` — full suite passes, including the 3 new tests
  (`lint_openapi_service_definition_skips_missing_id_warning`,
  `lint_openrpc_service_definition_skips_missing_id_warning`,
  `lint_non_string_openapi_property_still_warns`).
- `cargo clippy --all-targets -- -D warnings` — clean (exit 0).
- `cargo fmt --check` — clean.
- End-to-end against `Universal-Commerce-Protocol/ucp@7dc6c11`:

  | | `ucp-schema lint --strict source/` |
  | --- | --- |
  | before (released 1.4.1) | `exit 1` — 100 checked, 94 passed, **6 failed** |
  | after | `exit 0` — **100 checked, all passed** |

- Non-strict `ucp-schema lint source/` output is byte-identical before and after
  apart from the removed warnings, confirming no other behaviour changed.

## Follow-up (not in this PR)

With this fixed, `ucp-schema lint --strict source/` becomes adoptable in the UCP
repo's CI. That is a natural next step for
[`.github#21`](https://github.com/Universal-Commerce-Protocol/.github/issues/21),
but it has to wait for a release carrying this change.
