### PR TITLE
fix: validate capability version dates

### DIFF
--- a/src/compose.rs
+++ b/src/compose.rs
@@ -45,7 +45,7 @@ use serde_json::{json, Value};
 
 use crate::error::ComposeError;
 use crate::loader::{bundle_refs, bundle_refs_with_url_mapping, is_url, load_schema};
-use crate::types::{Direction, Requires, VersionConstraint};
+use crate::types::{is_valid_version, Direction, Requires, VersionConstraint};
 
 #[cfg(feature = "remote")]
 use crate::loader::{bundle_refs_remote, load_schema_url};
@@ -249,8 +249,17 @@ fn parse_capabilities_object(caps: &Value) -> Result<Vec<Capability>, ComposeErr
             .ok_or_else(|| ComposeError::InvalidCapability {
                 name: name.clone(),
                 message: "missing version field".to_string(),
-            })?
-            .to_string();
+            })?;
+        if !is_valid_version(version) {
+            return Err(ComposeError::InvalidCapability {
+                name: name.clone(),
+                message: format!(
+                    "invalid version \"{}\" (expected a valid YYYY-MM-DD date)",
+                    version
+                ),
+            });
+        }
+        let version = version.to_string();
 
         let schema_url = entry
             .get("schema")
@@ -1001,6 +1010,24 @@ mod tests {
         assert_eq!(result[0].name, "dev.ucp.shopping.checkout");
         assert_eq!(result[0].version, "2026-01-11");
         assert!(result[0].extends.is_none());
+    }
+
+    #[test]
+    fn parse_capabilities_rejects_invalid_version() {
+        let caps = json!({
+            "dev.ucp.shopping.checkout": [{
+                "version": "not-a-date",
+                "schema": "https://ucp.dev/schemas/shopping/checkout.json"
+            }]
+        });
+
+        let err = parse_capabilities_object(&caps).unwrap_err();
+        assert!(matches!(
+            err,
+            ComposeError::InvalidCapability { name, message }
+                if name == "dev.ucp.shopping.checkout"
+                    && message.contains("valid YYYY-MM-DD date")
+        ));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -125,9 +125,18 @@ pub fn is_valid_version(s: &str) -> bool {
     }) {
         return false;
     }
+    let year: u16 = s[..4].parse().unwrap_or(0);
     let month: u8 = s[5..7].parse().unwrap_or(0);
     let day: u8 = s[8..10].parse().unwrap_or(0);
-    (1..=12).contains(&month) && (1..=31).contains(&day)
+    let leap_year = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+    let days_in_month = match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if leap_year => 29,
+        2 => 28,
+        _ => return false,
+    };
+    (1..=days_in_month).contains(&day)
 }
 
 /// Version range: minimum (required) and optional maximum, both inclusive.
@@ -143,6 +152,15 @@ pub struct VersionConstraint {
 impl VersionConstraint {
     /// Check if a version satisfies this constraint.
     pub fn satisfied_by(&self, version: &str) -> bool {
+        if !is_valid_version(version)
+            || !is_valid_version(&self.min)
+            || self
+                .max
+                .as_deref()
+                .is_some_and(|max| !is_valid_version(max))
+        {
+            return false;
+        }
         if version < self.min.as_str() {
             return false;
         }
@@ -368,6 +386,12 @@ mod tests {
         assert!(!is_valid_version("2026-00-15"));
         assert!(!is_valid_version("2026-06-00"));
         assert!(!is_valid_version("9999-99-99"));
+        assert!(!is_valid_version("2026-02-29"));
+        assert!(!is_valid_version("2026-02-31"));
+        assert!(!is_valid_version("2026-04-31"));
+        assert!(is_valid_version("2024-02-29"));
+        assert!(is_valid_version("2000-02-29"));
+        assert!(!is_valid_version("1900-02-29"));
     }
 
     #[test]
@@ -380,6 +404,8 @@ mod tests {
         assert!(min_only.satisfied_by("2026-01-23")); // inclusive
         assert!(min_only.satisfied_by("2026-06-01"));
         assert!(min_only.satisfied_by("2099-12-31"));
+        assert!(!min_only.satisfied_by("not-a-date"));
+        assert!(!min_only.satisfied_by("2026-02-31"));
 
         let range = VersionConstraint {
             min: "2026-01-23".into(),


### PR DESCRIPTION
# Description

Fix capability version validation to prevent malformed or impossible date strings from bypassing requires compatibility checks.

Validate capability versions during parsing.
Reject invalid actual versions before lexicographical comparison.
Validate Gregorian calendar dates, including month lengths and leap years.
Add regression tests for malformed versions, invalid dates, and leap-year boundaries.
## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [x] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

<!-- Link to any related issues here. e.g., "Fixes #123" -->

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [ ] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

$ cargo test --all-targets
test result: ok. 154 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 78 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 68 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

Unit tests covering this fix:

1. types::tests::is_valid_version_format
   - valid versions: 2026-01-23, 2025-12-31
   - invalid formats: 2026-1-23, not-a-date, 20260123, empty string
   - invalid calendar dates: 2026-13-32, 2026-00-15, 2026-06-00, 9999-99-99
   - invalid month/day combinations: 2026-02-29, 2026-02-31, 2026-04-31
   - leap-year handling: accepts 2024-02-29, accepts 2000-02-29, rejects 1900-02-29

2. types::tests::version_constraint_satisfied_by
   - rejects versions below min
   - accepts min boundary inclusively
   - accepts versions within range
   - accepts max boundary inclusively
   - rejects versions above max
   - rejects invalid actual versions: not-a-date, 2026-02-31

3. compose::tests::parse_capabilities_rejects_invalid_version
   - rejects a capability entry whose version is not-a-date
   - returns ComposeError::InvalidCapability
