### PR TITLE
fix: preserve recursive internal refs during bundling

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -185,7 +185,13 @@ fn bundle_refs_inner(
                     if ref_val == "#" {
                         // Leave as-is - can't inline recursive self-reference
                     } else if let Some(root) = file_root {
+                        let visit_key = internal_ref_visit_key(root, ref_val);
+                        if visited.contains(&visit_key) {
+                            return Ok(());
+                        }
+
                         let mut target = navigate_fragment(root, ref_val)?;
+                        visited.insert(visit_key.clone());
                         // Recursively process (may have nested refs)
                         bundle_refs_inner(
                             &mut target,
@@ -195,6 +201,7 @@ fn bundle_refs_inner(
                             url_remote_base,
                             visited,
                         )?;
+                        visited.remove(&visit_key);
                         // Inline the resolved definition
                         obj.remove("$ref");
                         if let Value::Object(ref_obj) = target {
@@ -302,6 +309,10 @@ fn bundle_refs_inner(
     Ok(())
 }
 
+fn internal_ref_visit_key(root: &Value, ref_val: &str) -> String {
+    format!("internal:{:p}|{}", root, ref_val)
+}
+
 /// Resolve a $ref value to a local file path.
 ///
 /// If URL mapping is configured and the ref matches the remote base,
@@ -361,8 +372,15 @@ fn bundle_refs_remote_inner(
                     if ref_val == "#" {
                         // Self-reference, leave as-is
                     } else if let Some(root) = file_root {
+                        let visit_key = internal_ref_visit_key(root, ref_val);
+                        if visited.contains(&visit_key) {
+                            return Ok(());
+                        }
+
                         let mut target = navigate_fragment(root, ref_val)?;
+                        visited.insert(visit_key.clone());
                         bundle_refs_remote_inner(&mut target, base_url, file_root, visited)?;
+                        visited.remove(&visit_key);
                         obj.remove("$ref");
                         if let Value::Object(ref_obj) = target {
                             for (k, v) in ref_obj {
@@ -597,6 +615,28 @@ mod tests {
         assert_eq!(path, Path::new("/local/schemas/foo.json"));
     }
 
+    #[test]
+    fn bundle_refs_preserves_recursive_internal_ref() {
+        let mut schema = serde_json::json!({
+            "$defs": {
+                "node": {
+                    "type": "object",
+                    "properties": {
+                        "next": {
+                            "$ref": "#/$defs/node"
+                        }
+                    }
+                }
+            },
+            "$ref": "#/$defs/node"
+        });
+
+        bundle_refs(&mut schema, Path::new(".")).unwrap();
+
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["properties"]["next"]["$ref"], "#/$defs/node");
+    }
+
     // Remote tests run against a local mockito server so they're deterministic
     // and offline — no dependency on a live third party. The connection-error
     // case uses a reserved `.invalid` host (RFC 2606), which fails to resolve
@@ -655,6 +695,28 @@ mod tests {
             let result = load_schema_auto(&format!("{}/schema.json", server.url()));
             assert_eq!(result.unwrap()["type"], "string");
             mock.assert();
+        }
+
+        #[test]
+        fn bundle_refs_remote_preserves_recursive_internal_ref() {
+            let mut schema = serde_json::json!({
+                "$defs": {
+                    "node": {
+                        "type": "object",
+                        "properties": {
+                            "next": {
+                                "$ref": "#/$defs/node"
+                            }
+                        }
+                    }
+                },
+                "$ref": "#/$defs/node"
+            });
+
+            bundle_refs_remote(&mut schema, "https://example.com/schema.json").unwrap();
+
+            assert_eq!(schema["type"], "object");
+            assert_eq!(schema["properties"]["next"]["$ref"], "#/$defs/node");
         }
     }
 }


### PR DESCRIPTION
# Description

Fix recursive internal `$ref` bundling to prevent stack overflow when schemas reference themselves through fragments such as `#/$defs/node`.

For example, a schema may define a recursive linked-list-like node:

```json
{
  "$defs": {
    "node": {
      "type": "object",
      "properties": {
        "next": {
          "$ref": "#/$defs/node"
        }
      }
    }
  },
  "$ref": "#/$defs/node"
}
```

This is valid JSON Schema: `next` points back to the same `node` definition.

Before this fix, the bundler tried to inline every internal `$ref`. It expanded the root `$ref` into `$defs.node`, then saw `properties.next.$ref = "#/$defs/node"`, expanded the same definition again, and repeated forever until the process hit a stack overflow.

After this fix, the bundler tracks the internal fragments currently being expanded. When it sees the same fragment again during expansion, it stops inlining that recursive edge and preserves the original `$ref`. This prevents infinite recursion while keeping the schema's recursive meaning intact.

This fix applies to both local/URL-mapped bundling and remote bundling.
## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [x] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

<!-- Link to any related issues here. e.g., "Fixes #123" -->

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

Targeted regression tests for this fix passed:

$ cargo test bundle_refs_preserves_recursive_internal_ref bundle_refs_remote_preserves_recursive_internal_ref
test loader::tests::bundle_refs_preserves_recursive_internal_ref ... ok
test loader::tests::remote::bundle_refs_remote_preserves_recursive_internal_ref ... ok

Full local validation also passed:

$ cargo fmt --check
passed

$ git diff --check
passed

$ cargo clippy --all-targets -- -D warnings
passed

$ cargo test --all-targets
test result: ok. 155 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 78 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 68 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
