### PR TITLE
docs: document include-future resolve option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Options:
   --schema-local-base <dir>   Local directory for schema resolution
   --schema-remote-base <url>  URL prefix to strip when mapping to local
   --strict                    Inject additionalProperties: false (see Concepts > Strict Mode)
+  --include-future            Include planned fields with transition metadata, but not in required
   --verbose, -v               Print pipeline stages to stderr
 ```
 


### PR DESCRIPTION
## Description

The `resolve` command already exposes `--include-future`, but the README option list jumps from `--strict` directly to `--verbose`. As a result, the documented command reference does not show how to surface planned fields whose visibility transitions from `omit` to a non-omit state.

The CLI help defines the behavior as:

```text
--include-future
    Include future fields: omit-visibility fields with a transition targeting
    non-omit (planned additions). Surfaces them with x-ucp-schema-transition
    metadata but does not add to required.
```

**Fix:** add the existing option to the README's `resolve` reference, including its transition metadata and `required` behavior.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `ucp-schema resolve --help` includes `--include-future`.
- `pre-commit run --all-files` passed.
- `cargo test --all-targets` passed: 314 tests.
- `git diff --check` passed.
