### PR TITLE
test: cover lint command output and exit codes

### DIFF
--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1424,6 +1424,76 @@ mod compose {
     }
 }
 
+mod lint_command {
+    use super::*;
+
+    #[test]
+    fn valid_schema_succeeds() {
+        let dir = TempDir::new().unwrap();
+        let schema = write_temp_file(
+            &dir,
+            "schema.json",
+            r#"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/schema.json",
+                "type": "object",
+                "properties": { "id": { "type": "string" } }
+            }"#,
+        );
+
+        cmd()
+            .args(["lint", schema.to_str().unwrap()])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("all passed"));
+    }
+
+    #[test]
+    fn broken_internal_ref_fails_with_diagnostic_code() {
+        let dir = TempDir::new().unwrap();
+        let schema = write_temp_file(
+            &dir,
+            "schema.json",
+            r##"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/schema.json",
+                "$ref": "#/$defs/missing"
+            }"##,
+        );
+
+        cmd()
+            .args(["lint", schema.to_str().unwrap()])
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains("E003"));
+    }
+
+    #[test]
+    fn json_output_is_parseable() {
+        let dir = TempDir::new().unwrap();
+        let schema = write_temp_file(
+            &dir,
+            "schema.json",
+            r#"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/schema.json",
+                "type": "string"
+            }"#,
+        );
+
+        let assert = cmd()
+            .args(["lint", schema.to_str().unwrap(), "--format", "json"])
+            .assert()
+            .success();
+        let output: serde_json::Value =
+            serde_json::from_slice(&assert.get_output().stdout).unwrap();
+
+        assert_eq!(output["files_checked"], 1);
+        assert_eq!(output["errors"], 0);
+        assert_eq!(output["results"].as_array().unwrap().len(), 1);
+    }
+}
+
 /// Compose subcommand tests — output composed schemas (annotations preserved)
 mod compose_command {
     use super::*;


### PR DESCRIPTION
## Description

`src/linter.rs` has unit coverage for individual diagnostics, but the public
`ucp-schema lint` command had no CLI integration tests. Other commands in
`tests/cli_test.rs` cover their argument handling, exit codes, and output, while
lint's command boundary remained unpinned:

```rust
fn run_lint(path: &Path, format: &str, strict: bool, quiet: bool) -> Result<(), u8>
```

A regression in clap wiring, the error exit code, or JSON serialization could
therefore pass all linter unit tests.

**Fix:** add CLI contract tests for a valid schema (exit 0), a broken internal
reference (`E003`, exit 1), and parseable `--format json` output with the
expected aggregate fields.

## Category (Required)

- [ ] **Core Protocol**: ...
- [ ] **Governance/Contributing**: ...
- [ ] **Capability**: ...
- [ ] **Documentation**: ...
- [ ] **Infrastructure**: ...
- [ ] **Maintenance**: ...
- [ ] **SDK**: ...
- [ ] **Samples / Conformance**: ...
- [x] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide ...
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under python_sdk. (Not applicable: ucp-schema test-only change.)

## Screenshots / Logs (if applicable)

N/A — the new lint CLI tests pass 3/3; the full Rust suite passes 318/318. Full pre-commit, rustfmt, codespell, and `git diff --check` also pass.
