### PR TITLE
fix: reject unsupported lint output formats

### DIFF
--- a/src/bin/ucp-schema.rs
+++ b/src/bin/ucp-schema.rs
@@ -796,6 +796,11 @@ fn report_error(json_output: bool, msg: &str) {
 fn run_lint(path: &Path, format: &str, strict: bool, quiet: bool) -> Result<(), u8> {
     use ucp_schema::Severity;
 
+    if !matches!(format, "text" | "json") {
+        eprintln!("Error: unsupported lint output format: {format}. Use 'text' or 'json'.");
+        return Err(2);
+    }
+
     if !path.exists() {
         eprintln!("Error: path not found: {}", path.display());
         return Err(2);

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1424,6 +1424,32 @@ mod compose {
     }
 }
 
+mod lint_command {
+    use super::*;
+
+    #[test]
+    fn unsupported_format_fails_before_linting() {
+        let dir = TempDir::new().unwrap();
+        let schema = write_temp_file(
+            &dir,
+            "schema.json",
+            r#"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/schema.json",
+                "type": "string"
+            }"#,
+        );
+
+        cmd()
+            .args(["lint", schema.to_str().unwrap(), "--format", "yaml"])
+            .assert()
+            .code(2)
+            .stderr(predicate::str::contains(
+                "unsupported lint output format: yaml",
+            ));
+    }
+}
+
 /// Compose subcommand tests — output composed schemas (annotations preserved)
 mod compose_command {
     use super::*;


### PR DESCRIPTION
## Description

`ucp-schema lint --help` documents the output format as `text` or `json`, but
`run_lint` only checked for `format == "json"` and silently treated any other
value as text:

```bash
ucp-schema lint schema.json --format yaml
# exit 0, text output
```

That hides typos in scripts that expect machine-readable output.

**Fix:** reject unsupported lint output formats at the command boundary with
exit code 2 and a clear error message, while keeping `text` and `json` behavior
unchanged.

## Category (Required)

- [ ] **Core Protocol**: ...
- [ ] **Governance/Contributing**: ...
- [ ] **Capability**: ...
- [ ] **Documentation**: ...
- [ ] **Infrastructure**: ...
- [ ] **Maintenance**: ...
- [ ] **SDK**: ...
- [ ] **Samples / Conformance**: ...
- [x] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide ...
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under python_sdk. (Not applicable: ucp-schema CLI fix.)

## Screenshots / Logs (if applicable)

N/A — `cargo test --test cli_test lint_command` passed 1/1 for the new test, the full Rust suite passed 316/316, and full pre-commit plus `git diff --check` passed.
