### PR TITLE
docs: pass values to strict mode flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Options:
   --bundle                    Inline external $ref pointers (schema input only; payloads bundle automatically)
   --schema-local-base <dir>   Local directory for schema resolution
   --schema-remote-base <url>  URL prefix to strip when mapping to local
-  --strict                    Inject additionalProperties: false (see Concepts > Strict Mode)
+  --strict <true|false>       Inject additionalProperties: false (see Concepts > Strict Mode)
   --verbose, -v               Print pipeline stages to stderr
 ```
 
@@ -146,7 +146,7 @@ Options:
                                {op}_{direction} (see Concepts > Container Capabilities)
   --schema-local-base <dir>    Local directory to resolve schema URLs
   --schema-remote-base <url>   URL prefix to strip when mapping to local
-  --strict                     Reject unknown fields (see Concepts > Strict Mode)
+  --strict <true|false>        Reject unknown fields (see Concepts > Strict Mode)
   --json                       Machine-readable JSON output
   --verbose, -v                Print pipeline stages to stderr
 ```
@@ -586,8 +586,8 @@ How it works:
 By default, validation allows unknown fields — payloads may contain fields from capabilities the validator hasn't seen, and forward compatibility requires tolerating them. For closed systems or catching typos, `--strict` injects `additionalProperties: false` into all object schemas:
 
 ```bash
-ucp-schema validate order.json --schema schema.json --request --op create --strict
-ucp-schema resolve schema.json --request --op create --strict --pretty
+ucp-schema validate order.json --schema schema.json --request --op create --strict true
+ucp-schema resolve schema.json --request --op create --strict true --pretty
 ```
 
 **Warning:** Strict mode conflicts with `allOf` composition. Each `allOf` branch validates independently and rejects properties from other branches. Use default (non-strict) mode for composed schemas.


### PR DESCRIPTION
## Description

The Strict Mode examples pass `--strict` without a value:

```bash
ucp-schema validate order.json --schema schema.json --request --op create --strict
ucp-schema resolve schema.json --request --op create --strict --pretty
```

For `resolve` and `validate`, clap defines this option as `--strict <STRICT>`
with `true` and `false` as the possible values. Both commands therefore exit 2
before loading their inputs:

```text
error: a value is required for '--strict <STRICT>' but none was supplied
```

Passing `--strict true` parses successfully. The separate `lint --strict` flag
remains a value-less switch.

**Fix:** document the required value in the resolve and validate option lists,
and pass `true` in both Strict Mode examples.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- The old resolve and validate examples exit 2 during argument parsing.
- Adding `--strict true` passes argument parsing and reaches input loading.
- Cargo build, the full pre-commit suite, and `git diff --check` passed.
