### PR TITLE
fix: detect nullable allOf type conflicts

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -600,13 +600,48 @@ fn inject_annotations(
     Ok(branch)
 }
 
-/// Validate that allOf branches don't declare contradictory types on the same property.
+/// Return the JSON instance types accepted by a `type` keyword.
 ///
-/// Only checks string-form `"type"` values. Array-form types (e.g. `["string", "null"]`)
-/// are intentionally skipped — they're rare and the semantic comparison is non-trivial.
+/// `number` includes integer instances. Invalid type expressions are left for
+/// JSON Schema validation rather than treated as conflicts here.
+fn accepted_json_types(value: &Value) -> Option<std::collections::HashSet<&'static str>> {
+    fn insert_type(value: &str, types: &mut std::collections::HashSet<&'static str>) -> Option<()> {
+        let value = match value {
+            "null" => "null",
+            "boolean" => "boolean",
+            "object" => "object",
+            "array" => "array",
+            "number" => "number",
+            "integer" => "integer",
+            "string" => "string",
+            _ => return None,
+        };
+        types.insert(value);
+        if value == "number" {
+            types.insert("integer");
+        }
+        Some(())
+    }
+
+    let mut types = std::collections::HashSet::new();
+    match value {
+        Value::String(value) => insert_type(value, &mut types)?,
+        Value::Array(values) if !values.is_empty() => {
+            for value in values {
+                insert_type(value.as_str()?, &mut types)?;
+            }
+        }
+        _ => return None,
+    }
+    Some(types)
+}
+
+/// Validate that allOf branches don't declare disjoint types on the same property.
 fn validate_allof_types(branches: &[Value], path: &str) -> Result<(), ResolveError> {
-    let mut prop_types: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
+    let mut prop_types: std::collections::HashMap<
+        String,
+        (std::collections::HashSet<&'static str>, String),
+    > = std::collections::HashMap::new();
     for branch in branches {
         let props = branch
             .as_object()
@@ -615,18 +650,24 @@ fn validate_allof_types(branches: &[Value], path: &str) -> Result<(), ResolveErr
         if let Some(props) = props {
             for (name, prop) in props {
                 if let Some(type_val) = prop.as_object().and_then(|p| p.get("type")) {
-                    if let Some(type_str) = type_val.as_str() {
-                        if let Some(existing) = prop_types.get(name) {
-                            if existing != type_str {
-                                return Err(ResolveError::TypeConflict {
-                                    path: format!("{}/properties/{}", path, name),
-                                    base_type: existing.clone(),
-                                    ext_type: type_str.to_string(),
-                                });
-                            }
-                        } else {
-                            prop_types.insert(name.clone(), type_str.to_string());
+                    let Some(types) = accepted_json_types(type_val) else {
+                        continue;
+                    };
+                    let display = type_val
+                        .as_str()
+                        .map(str::to_string)
+                        .unwrap_or_else(|| type_val.to_string());
+                    if let Some((accepted, base_type)) = prop_types.get_mut(name) {
+                        accepted.retain(|value| types.contains(value));
+                        if accepted.is_empty() {
+                            return Err(ResolveError::TypeConflict {
+                                path: format!("{}/properties/{}", path, name),
+                                base_type: base_type.clone(),
+                                ext_type: display,
+                            });
                         }
+                    } else {
+                        prop_types.insert(name.clone(), (types, display));
                     }
                 }
             }

--- a/tests/resolve_test.rs
+++ b/tests/resolve_test.rs
@@ -1053,6 +1053,26 @@ mod allof_propagation {
     }
 
     #[test]
+    fn array_form_types_use_json_schema_intersection_semantics() {
+        let resolve_types = |base_type: Value, ext_type: Value| {
+            let schema = json!({
+                "allOf": [
+                    { "properties": { "value": { "type": base_type } } },
+                    { "properties": { "value": { "type": ext_type } } }
+                ]
+            });
+            resolve(&schema, &ResolveOptions::new(Direction::Response, "search"))
+        };
+
+        assert!(matches!(
+            resolve_types(json!(["string", "null"]), json!("number")),
+            Err(ResolveError::TypeConflict { .. })
+        ));
+        assert!(resolve_types(json!(["string", "null"]), json!("string")).is_ok());
+        assert!(resolve_types(json!("number"), json!("integer")).is_ok());
+    }
+
+    #[test]
     fn same_type_no_conflict() {
         let schema = json!({
             "allOf": [


### PR DESCRIPTION
## Description

`validate_allof_types` only compared string-form `type` keywords. An array-form type such as `["string", "null"]` was skipped, so combining it with `"number"` in another `allOf` branch passed resolution even though no JSON instance can satisfy both branches.

**Fix:** normalize string and array forms into accepted JSON instance-type sets and intersect them across matching properties. Empty intersections keep returning the existing `TypeConflict`; overlapping nullable types and the JSON Schema `number`/`integer` relationship remain valid.

The regression test covers all three boundaries:

- `["string", "null"]` with `"number"` reports a conflict
- `["string", "null"]` with `"string"` resolves
- `"number"` with `"integer"` resolves

## Category (Required)

- [ ] **Core Protocol**: Changes to core protocol specifications. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance or contributing processes. (Requires Governance Council approval)
- [ ] **Capability**: New or updated capabilities. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: Build, CI, or deployment changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependencies and repository maintenance. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [x] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Organization-wide community files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under `python_sdk` (not applicable).

## Screenshots / Logs (if applicable)

N/A — verified with `cargo test --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and all pre-commit hooks.
