### PR TITLE
fix: skip example instances during lint traversal

### DIFF
--- a/src/linter.rs
+++ b/src/linter.rs
@@ -221,6 +221,11 @@ fn check_examples(value: &Value, file: &Path, path: &str, diagnostics: &mut Vec<
                 }
             }
             for (key, child) in map {
+                // `examples` contains instance data, not nested schemas. Walking
+                // into it can reinterpret business fields as schema keywords.
+                if key == "examples" {
+                    continue;
+                }
                 let child_path = format!("{}/{}", path, key);
                 check_examples(child, file, &child_path, diagnostics);
             }
@@ -863,6 +868,27 @@ mod tests {
             result.diagnostics
         );
         assert_eq!(e008[0].path, "/examples/1");
+    }
+
+    #[test]
+    fn lint_does_not_recurse_into_example_instances() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/config.json",
+            "type": "object",
+            "examples": [{{
+                "type": "string",
+                "examples": [123]
+            }}]
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Ok);
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Description

`check_examples` validated each schema node's `examples` array and then recursively walked into that same array. Example values are instance data, not nested schemas. A valid object example containing business fields named `type` and `examples` was therefore reinterpreted as a schema and produced a false `E008` at `/examples/0/examples/0`.

**Fix:** stop schema traversal at the `examples` keyword after validating its entries. Other schema containers such as `properties`, `items`, composition branches, and `$defs` continue to be visited.

The regression test uses a valid object example whose own `examples` field contains the number `123`; linting now passes without diagnostics, while the existing invalid schema-level example test continues to report `E008`.

## Category (Required)

- [ ] **Core Protocol**: Changes to core protocol specifications. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance or contributing processes. (Requires Governance Council approval)
- [ ] **Capability**: New or updated capabilities. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: Build, CI, or deployment changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependencies and repository maintenance. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [x] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Organization-wide community files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under `python_sdk` (not applicable).

## Screenshots / Logs (if applicable)

N/A — verified with `cargo test --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, all pre-commit hooks, and the CLI regression fixture.
