### PR TITLE
fix: skip annotation checks in instance data

### DIFF
--- a/src/linter.rs
+++ b/src/linter.rs
@@ -345,8 +345,13 @@ fn check_annotations(value: &Value, file: &Path, path: &str, diagnostics: &mut V
             }
         }
 
-        // Recurse
+        // Recurse into child schemas, but not into keywords that hold JSON
+        // instance data. Business payloads may legitimately contain fields
+        // named like UCP annotations.
         for (key, val) in map {
+            if matches!(key.as_str(), "default" | "const" | "examples" | "enum") {
+                continue;
+            }
             let child_path = format!("{}/{}", path, key);
             check_annotations(val, file, &child_path, diagnostics);
         }
@@ -935,6 +940,31 @@ mod tests {
         let result = lint_file(file.path(), file.path().parent().unwrap());
         assert_eq!(result.status, FileStatus::Error);
         assert!(result.diagnostics.iter().any(|d| d.code == "E004"));
+    }
+
+    #[test]
+    fn lint_does_not_check_annotations_inside_instance_keywords() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "type": "object",
+            "default": {{ "ucp_request": "invalid_value" }},
+            "const": {{ "ucp_response": "invalid_value" }},
+            "examples": [{{ "ucp_response": "invalid_value" }}],
+            "enum": [{{ "ucp_response": "invalid_value" }}]
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Ok);
+        assert!(
+            !result.diagnostics.iter().any(|d| d.code == "E004"),
+            "instance data should not produce E004: {:?}",
+            result.diagnostics
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

`check_annotations` currently walks every object and array value in a schema. JSON Schema keywords such as `default`, `const`, `examples`, and `enum` contain instance data rather than child schemas, so payload fields named `ucp_request` or `ucp_response` inside those values can be misreported as invalid UCP annotations.

This change skips those instance-data keywords during annotation traversal while preserving validation for real schema locations. It also adds a regression test covering annotation-like field names inside `default`, `const`, `examples`, and `enum`.

## Category (Required)

- [x] Fix
- [ ] Test
- [ ] Docs
- [ ] Chore
- [ ] CI

## Related Issues

None.

## Checklist

- [x] I have read the contribution guidelines.
- [x] I have added or updated tests as appropriate.
- [x] I have run the relevant checks locally.

## Screenshots / Logs (if applicable)

- `cargo test --manifest-path /Users/bytedance/All/UCP/PR记录/worktrees/71-ucp-schema/Cargo.toml --all-targets`
- `cargo clippy --manifest-path /Users/bytedance/All/UCP/PR记录/worktrees/71-ucp-schema/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path /Users/bytedance/All/UCP/PR记录/worktrees/71-ucp-schema/Cargo.toml -- --check`
- `uvx pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`
