### PR TITLE
fix: preserve instance annotation fields

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -321,6 +321,11 @@ fn resolve_object(
                 // Will be handled at the end after processing properties
                 continue;
             }
+            "default" | "const" | "examples" | "enum" => {
+                // These keywords hold JSON instance data, not child schemas.
+                // Preserve business fields that happen to share UCP annotation names.
+                result.insert(key.clone(), value.clone());
+            }
             _ => {
                 // Other keys - recurse if object/array, otherwise copy
                 let resolved = resolve_value(value, options, &child_path)?;
@@ -640,9 +645,15 @@ fn strip_annotations_recursive(value: &Value) -> Value {
         Value::Object(map) => {
             let mut result = Map::new();
             for (k, v) in map {
-                if !UCP_ANNOTATIONS.contains(&k.as_str()) {
-                    result.insert(k.clone(), strip_annotations_recursive(v));
+                if UCP_ANNOTATIONS.contains(&k.as_str()) {
+                    continue;
                 }
+                let value = if matches!(k.as_str(), "default" | "const" | "examples" | "enum") {
+                    v.clone()
+                } else {
+                    strip_annotations_recursive(v)
+                };
+                result.insert(k.clone(), value);
             }
             Value::Object(result)
         }

--- a/tests/resolve_test.rs
+++ b/tests/resolve_test.rs
@@ -314,6 +314,33 @@ mod transformation {
     }
 
     #[test]
+    fn instance_data_preserves_annotation_like_field_names() {
+        let schema = json!({
+            "type": "object",
+            "ucp_request": "required",
+            "properties": {
+                "id": { "type": "string", "ucp_request": "required" }
+            },
+            "default": { "ucp_request": "business-value" },
+            "const": { "ucp_response": "business-value" },
+            "examples": [{ "ucp_request": "business-value" }],
+            "enum": [{ "ucp_response": "business-value" }]
+        });
+        let options = ResolveOptions::new(Direction::Request, "create");
+        let result = resolve(&schema, &options).unwrap();
+
+        assert!(result.get("ucp_request").is_none());
+        assert!(result["properties"]["id"].get("ucp_request").is_none());
+        assert_eq!(result["default"]["ucp_request"], json!("business-value"));
+        assert_eq!(result["const"]["ucp_response"], json!("business-value"));
+        assert_eq!(
+            result["examples"][0]["ucp_request"],
+            json!("business-value")
+        );
+        assert_eq!(result["enum"][0]["ucp_response"], json!("business-value"));
+    }
+
+    #[test]
     fn annotations_stripped_from_output() {
         let schema = json!({
             "type": "object",


### PR DESCRIPTION
## Description

`resolve_object` and `strip_annotations_recursive` recurse into every object and array value. `default`, `const`, `examples`, and `enum` hold JSON instance data rather than child schemas, so business fields named `ucp_request` or `ucp_response` inside those values were removed from resolved output.

**Fix:** preserve those four instance-data keyword values verbatim while continuing to remove annotations from real schema locations. The regression test verifies both behaviors in one resolved schema.

## Category (Required)

- [ ] **Core Protocol**: Changes to core protocol specifications, breaking changes, or extensions. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance documentation or contribution guidelines. (Requires Governance Council approval)
- [ ] **Capability**: Changes to a capability specification. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI, build, or developer tooling changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependencies or repository maintenance. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [x] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Community health files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `cargo test --manifest-path /Users/bytedance/All/UCP/PR记录/worktrees/72-ucp-schema/Cargo.toml --all-targets`
- `cargo clippy --manifest-path /Users/bytedance/All/UCP/PR记录/worktrees/72-ucp-schema/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path /Users/bytedance/All/UCP/PR记录/worktrees/72-ucp-schema/Cargo.toml -- --check`
- `uvx pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`
