### PR TITLE
fix: skip ref checks in instance data

### DIFF
--- a/src/linter.rs
+++ b/src/linter.rs
@@ -251,6 +251,11 @@ fn check_refs(
             }
 
             for (key, val) in map {
+                // These keywords hold JSON instance data, not child schemas.
+                // A business payload field named `$ref` should not be resolved.
+                if matches!(key.as_str(), "default" | "const" | "examples" | "enum") {
+                    continue;
+                }
                 let child_path = format!("{}/{}", path, key);
                 check_refs(val, file, file_dir, &child_path, root, diagnostics);
             }
@@ -913,6 +918,31 @@ mod tests {
         let result = lint_file(file.path(), file.path().parent().unwrap());
         assert_eq!(result.status, FileStatus::Error);
         assert!(result.diagnostics.iter().any(|d| d.code == "E002"));
+    }
+
+    #[test]
+    fn lint_does_not_check_refs_inside_instance_keywords() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+            "$id": "https://example.com/test.json",
+            "type": "object",
+            "default": {{ "$ref": "business-id" }},
+            "const": {{ "$ref": "business-id" }},
+            "examples": [{{ "$ref": "business-id" }}],
+            "enum": [{{ "$ref": "business-id" }}]
+        }}"#
+        )
+        .unwrap();
+
+        let result = lint_file(file.path(), file.path().parent().unwrap());
+        assert_eq!(result.status, FileStatus::Ok);
+        assert!(
+            !result.diagnostics.iter().any(|d| d.code == "E002"),
+            "instance data should not produce E002: {:?}",
+            result.diagnostics
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

`check_refs` currently walks every object and array value in a schema. `default`, `const`, `examples`, and `enum` hold JSON instance data, so a business field named `$ref` in one of those values was treated as a schema reference and reported as `E002`.

**Fix:** skip those instance-data keyword values during reference traversal while preserving checks at real schema locations. The regression test covers all four keyword values and the existing broken-reference tests continue to cover real `$ref` values.

## Category (Required)

- [ ] **Core Protocol**: Changes to core protocol specifications, breaking changes, or extensions. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance documentation or contribution guidelines. (Requires Governance Council approval)
- [ ] **Capability**: Changes to a capability specification. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI, build, or developer tooling changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependencies or repository maintenance. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [x] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Community health files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `cargo test --manifest-path /Users/bytedance/All/UCP/PR记录/worktrees/73-ucp-schema/Cargo.toml --all-targets`
- `cargo clippy --manifest-path /Users/bytedance/All/UCP/PR记录/worktrees/73-ucp-schema/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path /Users/bytedance/All/UCP/PR记录/worktrees/73-ucp-schema/Cargo.toml -- --check`
- `uvx pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`
