### PR TITLE
fix: stop crawl external refs and the local base retriever from doubling a path segment

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -196,11 +196,20 @@ impl jsonschema::Retrieve for UcpRetriever {
         uri: &jsonschema::Uri<String>,
     ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
         let uri = uri.as_str();
-        // 1. Explicit URL mapping wins.
+        // 1. Explicit URL mapping wins, when it resolves to a file that
+        //    actually exists. A `$ref` resolved (via URL join) against a
+        //    document whose declared `$id` sits one level deeper, in `$id`
+        //    terms, than its referrer's disk location doubles a path
+        //    segment here exactly as it can in step 3 below; falling
+        //    through instead of erroring lets the learned-anchor relocation
+        //    in step 3 recover the real file the same way it already does
+        //    for references with no explicit mapping configured.
         if let Some((local, remote)) = &self.mapping {
             if let Some(rest) = uri.strip_prefix(remote.trim_end_matches('/')) {
                 let path = local.join(rest.trim_start_matches('/'));
-                return Ok(self.load_and_learn(&path)?);
+                if path.exists() {
+                    return Ok(self.load_and_learn(&path)?);
+                }
             }
         }
         // 2. file:// URIs load directly. Parse rather than strip the scheme:
@@ -357,7 +366,7 @@ fn crawl_external_refs(
                     None => {
                         claimed.insert(fetched_base.clone(), uri.clone());
                         seen.insert(fetched_base.clone());
-                        resources.push((fetched_base, fetched));
+                        resources.push((fetched_base, fetched.clone()));
                     }
                     Some(first) if *first != uri => {
                         return Err(ResolveError::BundleError {
@@ -368,6 +377,22 @@ fn crawl_external_refs(
                     }
                     Some(_) => {}
                 }
+                // `uri` is a retrieval URI that does not match this
+                // document's own `$id` — it was only reachable because a
+                // relative `$ref` in the *referrer* was written against a
+                // directory layout that does not match the referrer's
+                // declared `$id` (e.g. a sibling-on-disk directory nested
+                // one level deeper in the `$id` namespace). Upstream
+                // dereference resolves this document's *own* relative
+                // `$ref`s against the URI it retrieved the document under,
+                // not against the document's declared `$id`, so every
+                // resource this document points to must also be reachable
+                // (and registered) relative to `uri`, or upstream dereference
+                // fails with "not present in a registry" the moment it
+                // re-derives the same join independently. Crawl this
+                // document's own refs a second time under `uri` so both
+                // bases are covered.
+                queue.push((fetched, uri));
             }
         }
     }

--- a/tests/conformance_test.rs
+++ b/tests/conformance_test.rs
@@ -496,6 +496,145 @@ fn transitively_referenced_documents_resolve() {
     assert!(!oracle_is_valid(&bundled, &json!({ "mid": { "leaf": 0 } })));
 }
 
+/// A referencing document's declared `$id` can imply a directory nested
+/// one level deeper than its actual disk location relative to a sibling
+/// directory (real shape: a UCP source checkout where `discovery/` sits on
+/// disk beside `schemas/`, but `discovery/profile_schema.json` declares
+/// `$id: https://ucp.dev/schemas/discovery/profile.json` — nesting
+/// `discovery` *under* `schemas` in URL terms). A relative `$ref` written
+/// to be correct on disk (`../shared/mid.json`, walking up to the common
+/// parent and back down into the sibling) is then wrong when resolved by
+/// pure URL join against the declared `$id`: it doubles the shared
+/// directory segment (`shared/shared/mid.json`).
+///
+/// The retriever still locates the right file on disk (its directory-anchor
+/// relocation cancels the extra segment), but upstream dereference
+/// independently re-derives the same doubled URI when it resolves the
+/// referencing document's `$ref`, and then resolves *that* document's own
+/// relative refs against the URI it was reached by rather than its
+/// declared `$id` — so any further hop must be reachable under the doubled
+/// base too, or bundling fails with "not present in a registry" even
+/// though every file exists exactly where its `$id` and disk layout
+/// (independently) say it should.
+#[test]
+fn sibling_directory_nested_under_id_resolves_without_doubling() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("outer")).unwrap();
+    fs::create_dir_all(dir.path().join("shared")).unwrap();
+    fs::write(
+        dir.path().join("outer/entry.json"),
+        json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.test/shared/outer/entry.json",
+            "$ref": "../shared/mid.json#/$defs/base"
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("shared/mid.json"),
+        json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.test/shared/mid.json",
+            "$defs": {
+                "base": {
+                    "type": "object",
+                    "properties": { "code": { "$ref": "leaf.json" } },
+                    "required": ["code"],
+                    "additionalProperties": false
+                }
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("shared/leaf.json"),
+        json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.test/shared/leaf.json",
+            "type": "string",
+            "pattern": "^[a-z]+$"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let bundled = bundle(dir.path(), "outer/entry.json");
+    assert!(oracle_is_valid(&bundled, &json!({ "code": "abc" })));
+    assert!(
+        !oracle_is_valid(&bundled, &json!({ "code": "ABC" })),
+        "leaf.json's pattern must survive being reached through the doubled base"
+    );
+    assert!(!oracle_is_valid(&bundled, &json!({})));
+}
+
+/// The same sibling/nested-under-`$id` layout mismatch, through
+/// `bundle_refs_with_url_mapping` (the `--schema-local-base` +
+/// `--schema-remote-base` pair, also used internally by `compose` for
+/// cross-URL capability schema resolution). The two bundling entry points
+/// share the same `crawl_external_refs` core, but
+/// `bundle_refs_with_url_mapping` had no direct test before this; its only
+/// prior coverage came through CLI fixtures whose declared `$id` and disk
+/// layout agree.
+#[test]
+fn sibling_directory_nested_under_id_resolves_without_doubling_with_url_mapping() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("outer")).unwrap();
+    fs::create_dir_all(dir.path().join("shared")).unwrap();
+    fs::write(
+        dir.path().join("outer/entry.json"),
+        json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.test/draft/shared/outer/entry.json",
+            "$ref": "../shared/mid.json#/$defs/base"
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("shared/mid.json"),
+        json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.test/draft/shared/mid.json",
+            "$defs": {
+                "base": {
+                    "type": "object",
+                    "properties": { "code": { "$ref": "leaf.json" } },
+                    "required": ["code"],
+                    "additionalProperties": false
+                }
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("shared/leaf.json"),
+        json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.test/draft/shared/leaf.json",
+            "type": "string",
+            "pattern": "^[a-z]+$"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let path = dir.path().join("outer/entry.json");
+    let mut schema = load_schema(&path).unwrap();
+    ucp_schema::bundle_refs_with_url_mapping(
+        &mut schema,
+        path.parent().unwrap(),
+        dir.path(),
+        "https://example.test/draft",
+    )
+    .expect("bundling succeeds");
+
+    assert!(oracle_is_valid(&schema, &json!({ "code": "abc" })));
+    assert!(!oracle_is_valid(&schema, &json!({ "code": "ABC" })));
+}
+
 /// A fragment ref into a fetched resource whose target pointer-refs a
 /// *sibling* definition: `#/$defs/wrapper` inside lib.json refs
 /// `#/$defs/base` — both pointers must keep resolving within lib.json.


### PR DESCRIPTION
## Root cause

Introduced by #66, commit 9f91c3d497d8f9d7f4051fbfb49b2262536acfd7. Bisected the range between 9b5c3206 (good) and b52518f5 (bad) commit by commit; 9f91c3d is the first bad one, and the two docs only commits after it do not change the result. #66 is otherwise a sound rework that closed #43, #45 and #46; this is one layout shape it did not cover.

crawl_external_refs in src/loader.rs resolves the relative refs of a fetched document against its declared $id (fetched_base), which is correct on its own, but upstream jsonschema::dereference resolves the relative refs of a fetched resource against the URI it was retrieved under, not its declared $id. When a relative ref is written correctly for the referrer disk location, but the referrer $id nests it one level deeper than a sibling directory (discovery beside schemas, both under https://ucp.dev/schemas/...), the URL join off the retrieval position doubles the shared segment. Only the correct, undoubled key from our own crawl had ever been registered, so upstream dereference fails with not present in a registry the moment it independently rederives the doubled key for a further hop.

A related site: the UcpRetriever explicit schema local base plus schema remote base mapping (step 1) hits the same doubled join and returns a hard file not found error instead of falling through to the learned anchor relocation in step 3, which already recovers from this mismatch for the no remote base case.

## Fix

Both changes are additive.

- crawl_external_refs: when the declared $id of a fetched document differs from the URI it was retrieved under, crawl the refs of that document a second time using the retrieval URI as base, in addition to the existing pass using its declared $id, so resources reachable through either base end up registered. The second pass is guarded on that difference, so it is a no op when the two agree.
- UcpRetriever::retrieve: only return the explicit mapping candidate when the mapped path exists on disk, falling through to the remaining steps otherwise, exactly as an unmapped URI already does. One behavior delta to name: a mapped URI whose local file is missing used to fail hard at the mapping step and now takes the same fallthrough as every unmapped URI, which with the remote feature can end in a network fetch.

## Tests

Added to tests/conformance_test.rs, matching the bundle and oracle_is_valid idiom already used in the file (accept and reject verdicts checked through the jsonschema crate, never our own emitted schema text):

- sibling_directory_nested_under_id_resolves_without_doubling reproduces the shape through bundle_refs, the path exercised by validate --schema --schema-local-base with no remote base.
- sibling_directory_nested_under_id_resolves_without_doubling_with_url_mapping covers the same shape through bundle_refs_with_url_mapping (schema local base plus schema remote base, also used internally by compose), which had no direct test before this change; its only prior coverage came through CLI fixtures whose declared $id and disk layout agree.

Each fails before the fix with the failure shape of its own site: the first with the same not present in a registry error the real repro produces, the second with a doubled path file not found error at the explicit mapping step. Both pass after. Reverting src/loader.rs alone with the tests kept turns both red again with those same shapes, confirming they test the fix rather than passing on their own.

## Verification

- The exact reported command now passes against a real ucp v2026-04-08 source checkout: exit 0, Valid (was exit 2 on main).
- cargo test --all-targets: 355 passed, 0 failed, 0 ignored.
- The #45 and #46 regression fixtures, the four Draft 2020 12 conformance cases #66 itself added, and every other recursion, self ref, and def selection test in the suite still pass, confirming this does not resurrect either stack overflow.
- The released v2026-08-25 tree is unaffected: lint over its source directory passes identically (124 files), and def selection on common/types/payment_instrument.json returns identical verdicts and messages on main and on this branch, in both the accept and the reject direction.
- cargo fmt --check and cargo clippy --all-targets -- -D warnings are both clean.

Fixes #71.
