### PR TITLE
docs: clarify explicit schema validation direction

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -49,7 +49,7 @@ This means you can develop and test third-party extensions locally before publis
 
 ## How does direction auto-detection work?
 
-**The validator infers direction from payload structure:**
+**For self-describing payloads, the validator infers direction from payload structure:**
 
 | Payload has        | Detected direction                               |
 | ------------------ | ------------------------------------------------ |
@@ -57,7 +57,11 @@ This means you can develop and test third-party extensions locally before publis
 | `meta.profile`     | Request                                          |
 | Neither            | Error (must specify `--request` or `--response`) |
 
-This applies to both `validate` and `resolve` when the input is a self-describing payload. When resolving a plain schema file, explicit `--request` or `--response` is required.
+This applies when `validate` or `resolve` receives a self-describing payload.
+When `validate` uses an explicit `--schema`, payload metadata is not required;
+if neither direction flag is set, validation defaults to request direction. Pass
+`--response` when validating against a response schema. When resolving a plain
+schema file, explicit `--request` or `--response` is required.
 
 ---
 


### PR DESCRIPTION
## Description

`FAQ.md` says payloads without `ucp.capabilities` or `meta.profile` always hit
an error and must pass `--request` or `--response`:

```markdown
| Neither | Error (must specify `--request` or `--response`) |
```

That is true for self-describing payloads, but explicit schema validation has a
different default. In the `validate --schema ...` path, the CLI falls back to
request direction when no direction flag is set:

```rust
determine_direction(request, response, None).unwrap_or(Direction::Request)
```

A minimal explicit schema validation with no payload metadata therefore succeeds
without either flag.

**Fix:** scope the table to self-describing payloads and document the explicit
`--schema` default, while keeping the existing note that resolving a plain schema
still requires an explicit direction.

## Category (Required)

- [ ] **Core Protocol**: Protocol specification changes. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Governance or contribution process changes. (Requires Governance Council approval)
- [ ] **Capability**: Capability specification changes. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation updates. (Requires Maintainer approval)
- [ ] **Infrastructure**: Build, CI, tooling, or release changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency, compatibility, or routine maintenance changes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [x] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Repository-wide health files and configuration. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under `python_sdk`.

## Screenshots / Logs (if applicable)

```text
$ cargo run --quiet -- validate /tmp/payload.json --schema /tmp/schema.json --op create
Valid

$ cargo test validate_schema_local_base_accepted_with_explicit_schema --test cli_test
1 passed

$ uvx pre-commit run --all-files
trim trailing whitespace...Passed
fix end of files...Passed
check yaml...Passed
check json...Passed
check for added large files...Passed
detect private key...Passed
check that scripts with shebangs are executable...Passed
prettier...Passed
fmt...Passed
codespell...Passed

$ git diff --check
# no output
```
