### PR TITLE
docs: fix README schema URLs to versioned 2026-04-08 path

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ ucp-schema resolve checkout.json --request --op create --bundle --pretty
 
 # Bundle a 3P extension with absolute URL refs (maps URLs to local copies)
 ucp-schema resolve my_extension.json --response --op read --bundle \
-  --schema-remote-base "https://ucp.dev/schemas" \
+  --schema-remote-base "https://ucp.dev/2026-04-08/schemas" \
   --schema-local-base ./local-ucp-schemas
 
 # Bundle a 3P extension with absolute URL refs (fetches from network)
@@ -377,11 +377,11 @@ UCP payloads are self-describing — they embed `ucp.capabilities` metadata decl
     "capabilities": {
       "dev.ucp.shopping.checkout": [{
         "version": "2026-01-11",
-        "schema": "https://ucp.dev/schemas/shopping/checkout.json"
+        "schema": "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json"
       }],
       "dev.ucp.shopping.discount": [{
         "version": "2026-01-11",
-        "schema": "https://ucp.dev/schemas/shopping/discount.json",
+        "schema": "https://ucp.dev/2026-04-08/schemas/shopping/discount.json",
         "extends": "dev.ucp.shopping.checkout"
       }]
     }
@@ -407,7 +407,7 @@ Extension schemas define their additions in `$defs` keyed by the root capability
 
 ```json
 {
-  "$id": "https://ucp.dev/schemas/shopping/discount.json",
+  "$id": "https://ucp.dev/2026-04-08/schemas/shopping/discount.json",
   "name": "dev.ucp.shopping.discount",
   "$defs": {
     "dev.ucp.shopping.checkout": {
@@ -485,7 +485,7 @@ ucp-schema validate envelope.json --schema transports/jsonrpc.json --op read --d
 
 ```json
 {
-  "$id": "https://ucp.dev/schemas/shopping/fulfillment.json",
+  "$id": "https://ucp.dev/2026-04-08/schemas/shopping/fulfillment.json",
   "name": "dev.ucp.shopping.fulfillment",
   "$defs": {
     "dev.ucp.shopping.catalog.search": {


### PR DESCRIPTION
# Description

Five `https://ucp.dev/schemas/...` URLs in the README return 404 — the published site
serves schemas under a versioned prefix (`/2026-04-08/schemas/...`). The already-merged
PR #57 fixed the `resolve` command example's URL; this PR covers the remaining unpatched
locations:

| Location | Before | After |
|----------|--------|-------|
| `--schema-remote-base` example (L123) | `https://ucp.dev/schemas` | `https://ucp.dev/2026-04-08/schemas` |
| Example payload `schema` field (L380) | `https://ucp.dev/schemas/shopping/checkout.json` | `/2026-04-08/schemas/shopping/checkout.json` |
| Example payload `schema` field (L384) | `https://ucp.dev/schemas/shopping/discount.json` | `/2026-04-08/schemas/shopping/discount.json` |
| `$id` demonstration (L410) | `https://ucp.dev/schemas/shopping/discount.json` | `/2026-04-08/schemas/shopping/discount.json` |
| `$id` demonstration (L488) | `https://ucp.dev/schemas/shopping/fulfillment.json` | `/2026-04-08/schemas/shopping/fulfillment.json` |

All five fixed URLs return HTTP 200; the unresolved URL table in the tool output
section (L552–618) is left unchanged — it is actual CLI output, not authorial prose.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [x] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A — the before/after URL table and curl exit codes are the repro.