### PR TITLE
fix: close explicitly open composition branches in strict mode

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -44,9 +44,17 @@ fn close_additional_properties(value: &mut Value) {
 ///
 /// `in_composition_branch` is true when processing direct children of allOf/anyOf/oneOf.
 /// We skip setting additionalProperties on these because each branch is validated
-/// independently and doesn't see properties from sibling branches.
+/// independently and doesn't see properties from sibling branches. An explicit
+/// `additionalProperties: true` is removed, however, so it cannot mark every unknown
+/// property as evaluated and bypass the parent's `unevaluatedProperties: false`.
 fn close_additional_properties_inner(value: &mut Value, in_composition_branch: bool) {
     if let Value::Object(map) = value {
+        if in_composition_branch
+            && matches!(map.get("additionalProperties"), Some(Value::Bool(true)))
+        {
+            map.remove("additionalProperties");
+        }
+
         // Check if this schema uses composition keywords
         let has_composition =
             map.contains_key("allOf") || map.contains_key("anyOf") || map.contains_key("oneOf");

--- a/tests/resolve_test.rs
+++ b/tests/resolve_test.rs
@@ -1659,6 +1659,41 @@ mod strict_mode {
     }
 
     #[test]
+    fn removes_explicit_true_from_allof_branches() {
+        let schema = json!({
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" }
+                    },
+                    "additionalProperties": true
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    }
+                }
+            ]
+        });
+        let options = ResolveOptions::new(Direction::Request, "create").strict(true);
+        let result = resolve(&schema, &options).unwrap();
+
+        assert_eq!(result["unevaluatedProperties"], json!(false));
+        assert!(result["allOf"][0].get("additionalProperties").is_none());
+        assert!(result["allOf"][1].get("additionalProperties").is_none());
+
+        let validator = jsonschema::validator_for(&result).unwrap();
+        assert!(validator.is_valid(&json!({ "id": "id_1", "name": "Ada" })));
+        assert!(!validator.is_valid(&json!({
+            "id": "id_1",
+            "name": "Ada",
+            "unexpected": true
+        })));
+    }
+
+    #[test]
     fn non_strict_mode_skips_injection() {
         // With strict=false, additionalProperties should not be touched
         let schema = json!({


### PR DESCRIPTION
## Description

Strict mode uses `unevaluatedProperties: false` on composition parents so
properties declared across `allOf` branches can coexist. A direct branch that
explicitly keeps `additionalProperties: true` defeats that closure:

```json
{
  "allOf": [
    {
      "type": "object",
      "properties": { "id": { "type": "string" } },
      "additionalProperties": true
    }
  ]
}
```

The branch marks every unknown property as evaluated, leaving nothing for the
parent's `unevaluatedProperties: false` to reject. This lets fields removed by
UCP operation annotations back into strict validation, as reported in #69.

**Fix:** remove an explicit `additionalProperties: true` from direct composition
branches in strict mode. Branches without the keyword remain untouched, so
properties declared by sibling branches still compose normally. The regression
asserts that a valid cross-branch payload passes while an extra unknown property
is rejected.

## Category (Required)

- [ ] **Core Protocol**: Changes to the UCP protocol itself. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance or contribution processes. (Requires Governance Council approval)
- [ ] **Capability**: Changes to an existing UCP capability. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: Changes to CI/CD or infrastructure. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency updates or routine maintenance. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [x] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Changes to shared GitHub configuration. (Requires DevOps Maintainer approval)

## Related Issues

Fixes #69

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under python_sdk (not applicable).

## Screenshots / Logs (if applicable)

- `cargo test` — 158 unit, 81 CLI, 27 conformance, 19 container, 69 resolver, and 1 doc test passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `uvx pre-commit run --all-files` — all 11 hooks passed
- CLI regression — valid cross-branch payload accepted; payload with an unknown property rejected
- `git diff --check` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
