### PR TITLE
fix: stop rewriting a required that is not an array of strings

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -259,7 +259,20 @@ fn resolve_object(
 ) -> Result<Value, ResolveError> {
     let mut result = Map::new();
 
-    // Track required array modifications
+    // Track required array modifications.
+    //
+    // `required` is only rewritten when it is well formed, that is an array of
+    // strings. A `required` that is any other shape is not a JSON Schema
+    // keyword we can reason about, so it is passed through untouched below
+    // rather than being replaced with an empty array. Replacing it silently
+    // discarded the constraint and left a schema that a validator would have
+    // rejected looking valid, and it also rewrote the unrelated boolean
+    // `required` that OpenAPI and OpenRPC service definitions carry.
+    let well_formed_required = map.get("required").is_none_or(|v| {
+        v.as_array()
+            .is_some_and(|arr| arr.iter().all(|e| e.is_string()))
+    });
+
     let original_required: Vec<String> = map
         .get("required")
         .and_then(|v| v.as_array())
@@ -330,7 +343,11 @@ fn resolve_object(
     }
 
     // Add updated required array if non-empty or if original existed
-    if !new_required.is_empty() || map.contains_key("required") {
+    if !well_formed_required {
+        if let Some(value) = map.get("required") {
+            result.insert("required".to_string(), value.clone());
+        }
+    } else if !new_required.is_empty() || map.contains_key("required") {
         result.insert(
             "required".to_string(),
             Value::Array(new_required.into_iter().map(Value::String).collect()),
@@ -870,6 +887,53 @@ mod tests {
         let required = result["required"].as_array().unwrap();
         assert!(!required.contains(&json!("id")));
         assert!(required.contains(&json!("name")));
+    }
+
+    #[test]
+    fn resolve_preserves_a_non_array_required() {
+        // A `required` that is not an array of strings is not a JSON Schema
+        // keyword this resolver can rewrite. It must survive untouched so the
+        // validator sees the authored value and rejects the schema, rather
+        // than being replaced with an empty array that silently drops the
+        // constraint and reports the schema as usable.
+        let schema = json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" } },
+            "required": "name"
+        });
+        let options = ResolveOptions::new(Direction::Request, "create");
+        let result = resolve(&schema, &options).unwrap();
+
+        assert_eq!(result["required"], json!("name"));
+    }
+
+    #[test]
+    fn resolve_preserves_a_boolean_required() {
+        // OpenAPI and OpenRPC parameter objects carry a boolean `required`.
+        // Those documents are resolved too, and the flag must not be rewritten
+        // into an empty array.
+        let schema = json!({
+            "name": "checkout",
+            "required": true,
+            "schema": { "type": "object" }
+        });
+        let options = ResolveOptions::new(Direction::Request, "create");
+        let result = resolve(&schema, &options).unwrap();
+
+        assert_eq!(result["required"], json!(true));
+    }
+
+    #[test]
+    fn resolve_preserves_required_with_a_non_string_element() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" } },
+            "required": ["name", 1]
+        });
+        let options = ResolveOptions::new(Direction::Request, "create");
+        let result = resolve(&schema, &options).unwrap();
+
+        assert_eq!(result["required"], json!(["name", 1]));
     }
 
     #[test]

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -281,6 +281,39 @@ mod validate_command {
     }
 
     #[test]
+    fn validate_rejects_a_schema_whose_required_is_not_an_array() {
+        // A malformed `required` used to be rewritten to an empty array during
+        // resolution, so the constraint vanished and an instance missing the
+        // field validated cleanly. The authored value now survives, the
+        // validator refuses the schema, and the run exits 2 rather than 0.
+        let dir = TempDir::new().unwrap();
+        let schema = write_temp_file(
+            &dir,
+            "schema.json",
+            r#"{
+                "type": "object",
+                "properties": { "name": { "type": "string" } },
+                "required": "name"
+            }"#,
+        );
+        let payload = write_temp_file(&dir, "payload.json", r#"{}"#);
+
+        cmd()
+            .args([
+                "validate",
+                payload.to_str().unwrap(),
+                "--schema",
+                schema.to_str().unwrap(),
+                "--request",
+                "--op",
+                "create",
+            ])
+            .assert()
+            .code(2)
+            .stderr(predicate::str::contains("invalid schema"));
+    }
+
+    #[test]
     fn validate_wrong_type() {
         let dir = TempDir::new().unwrap();
         let schema = write_temp_file(


### PR DESCRIPTION
## Observed

A schema whose `required` is a string rather than an array resolves to one whose
`required` is empty, and validation of an instance missing that field then
succeeds:

```
$ cat bad.json
{ "$schema": "https://json-schema.org/draft/2020-12/schema",
  "$id": "https://example.invalid/bad.json",
  "type": "object",
  "properties": { "name": { "type": "string" } },
  "required": "name" }

$ ucp-schema resolve bad.json --op create --request | jq .required
[]

$ ucp-schema validate empty.json --schema bad.json --request --op create --json
{"valid":true}          # exit 0
```

The pinned `jsonschema` crate would have refused that schema: `validator_for`
returns `"name" is not of type "array"`. The constraint is removed before it
gets there.

## Root cause

`resolve_object` seeds its required list with

```rust
map.get("required").and_then(|v| v.as_array()).….unwrap_or_default()
```

so a `required` of any other shape yields an empty list, and the emit branch
writes `"required": []` back out because the key was present. The authored
value is discarded with no diagnostic.

## Change

`required` is rewritten only when it is well formed, meaning an array of
strings. Anything else is passed through untouched, so the validator sees the
authored value and can reject the schema. An element that is not a string is
treated the same way, since a partial rewrite would drop it just as quietly.

## A second thing this fixes

OpenAPI and OpenRPC parameter objects carry a **boolean** `required`. Those
documents are resolved too, and the flag was being rewritten to `[]`, which
means nothing at that position. For example
`schemas/shopping/fulfillment.json` authors

```json
{ "name": "checkout", "required": true, "schema": { "$ref": "checkout.json" } }
```

and resolution turned that into `"required": []`. It now survives.

## Testing

Three resolver cases and one CLI case, each failing before this change and
passing after. Full suite **358 passed**, from 354. `cargo fmt --check` and
`cargo clippy --all-targets` are clean.

After the change, `validate` on the schema above reports
`invalid schema: "name" is not of type "array"` and exits **2**, while a well
formed schema with a genuinely missing field still exits **1**. The two failure
modes stay distinguishable.

## Blast radius, measured

Resolving every schema and service definition in the specification at
`release/2026-08-25`, in both directions, is 246 comparisons. **16 outputs
change and none errors.** Every change restores an authored value: six service
definitions and `schemas/shopping/fulfillment.json`, all of them the boolean
`required` described above. No schema in that tree has a malformed `required`
keyword, so nothing else moves.

The specification CI gates are unchanged, checked against a control binary:

| gate | baseline | with this change |
| :--- | :--- | :--- |
| `ucp-schema lint source/` | 124 files, all passed, 13 warnings | identical |
| `scripts/validate_examples.py` | 343 passed, 0 failed, 50 skipped | identical |

## Related, not addressed here

`lint` does not validate a schema document against the dialect its own
`$schema` declares, which is why the malformed schema above passes linting in
the first place. That is a separate change and I have not bundled it. Happy to
follow up if it is wanted.

Four open PRs touch `resolver.rs` (#48, #58, #62, #77). None of them touches the
required seeding or emit logic, so there is no overlap in substance, though
#77 and this may need a trivial rebase against each other.
